### PR TITLE
Add version and build date, silence build

### DIFF
--- a/src/app/esp8266/app.fth
+++ b/src/app/esp8266/app.fth
@@ -104,9 +104,19 @@ fl car.fth
 
 : init-i2c  ( -- )  3 4 i2c-setup  ;
 
+: .commit  ( -- )  'version cscount type  ;
+
+: .built  ( -- )  'build-date cscount type  ;
+
+: banner  ( -- )
+   cr ." CForth built " .built
+   ."  from " .commit
+   cr
+;
+
 \ Replace 'quit' to make CForth auto-run some application code
 \ instead of just going interactive.
-: app  ." CForth" cr hex init-i2c  quit  ;
+: app  banner  hex init-i2c  quit  ;
 
 alias id: \
 

--- a/src/app/esp8266/targets.mk
+++ b/src/app/esp8266/targets.mk
@@ -71,20 +71,26 @@ FORTH_OBJS = tembed.o textend.o
 DICTIONARY=ROM
 DICTSIZE=0x4000
 
-app.o: $(PLAT_OBJS) $(FORTH_OBJS)
+app.o: $(PLAT_OBJS) $(FORTH_OBJS) date.o
 	@echo Linking $@ ... 
-	$(TLD)  -o $@  -r  $(PLAT_OBJS) $(FORTH_OBJS)
+	@$(TLD)  -o $@  -r  $(PLAT_OBJS) $(FORTH_OBJS) date.o
+
+.PHONY: version
+
+version:
+	@echo "`git rev-parse --verify --short HEAD``if git diff-index --name-only HEAD >/dev/null; then echo '-dirty'; fi`" >$@ || echo UNKNOWN >$@
 
 # This rule builds a date stamp object that you can include in the image
 # if you wish.
 
 .PHONY: date.o
 
-date.o:
-	echo 'const char version[] = "'`cat version`'" ;' >date.c
-	echo 'const char build_date[] = "'`date  --iso-8601=minutes`'" ;' >>date.c
-	echo "const unsigned char sw_version[] = {" `cut -d . --output-delimiter=, -f 1,2 version` "};" >>date.c
-	$(TCC) -c date.c -o $@
+date.o: version
+	@echo 'const char version[] = "'`cat version`'";' >date.c
+	@echo 'const char build_date[] = "'`date --utc +%F\ %R`'";' >>date.c
+	@cat date.c
+	@echo TCC $@
+	@$(TCC) -c date.c -o $@
 
 EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS)
 

--- a/src/app/esp8266/textend.c
+++ b/src/app/esp8266/textend.c
@@ -307,7 +307,21 @@ void ow_reset_search() { onewire_reset_search(owpin); };
 void ow_target_search(uint8_t family_code) { onewire_target_search(owpin, family_code); };
 uint8_t ow_search(uint8_t *newAddr) { onewire_search(owpin, newAddr); };
 
+cell version_adr(void)
+{
+    extern char version[];
+    return (cell)version;
+}
+
+cell build_date_adr(void)
+{
+    extern char build_date[];
+    return (cell)build_date;
+}
+
 cell ((* const ccalls[])()) = {
+  C(build_date_adr)   //c 'build-date     { -- a.value }
+  C(version_adr)      //c 'version        { -- a.value }
   C(raw_putchar)      //c m-emit  { i.char -- }
 
   C(myspiffs_format)  //c fs-format  { -- }

--- a/src/cforth/embed/targets.mk
+++ b/src/cforth/embed/targets.mk
@@ -46,7 +46,8 @@ TLFLAGS = -static
 # putchar/getchar, and simple string routines like strcpy().
 
 tembed.o: $(TBASEOBJS) $(EMBEDOBJS) $(DICTOBJ)
-	$(TLD) -r -o $@ $(TBASEOBJS) $(EMBEDOBJS) $(DICTOBJ)
+	@echo TLD $<
+	@$(TLD) -r -o $@ $(TBASEOBJS) $(EMBEDOBJS) $(DICTOBJ)
 
 # tkernel.o is like tembed.o but it omits the dictionary so
 # that can be compiled separately


### PR DESCRIPTION
* set version from git hash and repository state,
* set build date from UTC HH:MM,
* add primitives `'version` and `'build-date`,
* add `.commit`, `.build`, and `banner` for user,
* show `banner` at start,
* hide some build commands.

Some names and style were borrowed from _arm-xo-1.75_.

Example output;
```
CForth built 2016-09-02 05:07 from fcc5c6f
ok █
```