### PR TITLE
ESP8266 TCP - connection closure error

### DIFF
--- a/src/app/esp8266/tcpnew.fth
+++ b/src/app/esp8266/tcpnew.fth
@@ -75,6 +75,7 @@ defer respond   ( pcb -- close? )
    ?dup 0=  if                  ( pbuf )
       ." Connection closed" cr cr
       rx-pcb close-connection   ( )
+      ERR_ABRT
       exit                      ( -- err )
    then                         ( pbuf )
 
@@ -89,8 +90,10 @@ defer respond   ( pcb -- close? )
    \ Give the data to the application code
    handle-data                  ( pbuf totlen )
 
-   \ Release the data buffer
+   \ Open the window
    rx-pcb tcp-recved            ( pbuf )
+
+   \ Release the data buffer
    pbuf-free drop               ( )
 
    \ Call the application code to respond to the data


### PR DESCRIPTION
According to stack effect comment and `lwip.c/recv_cb`, connection closure in `receiver` should return something.  Tested with returning `ERR_ABRT`, seems to work fine.  Perhaps some other value?

Also adjust comment for `tcp-recved`, which opens the TCP window by accounding for the bytes handled by the application.

(A local test application of mine calls `tcp-recved` before handling data.)

See 53151b3757167d7d83557365523f7a8273405132.