### PR TITLE
file-size stack effect comment

### DIFF
--- a/src/cforth/forth.c
+++ b/src/cforth/forth.c
@@ -1230,7 +1230,7 @@ execute:
     tos = pfflush(tos, up);     /* EOF on error */
     next;
 
-/*$p file-size */  case FILE_SIZE:
+/*$p file-size */  case FILE_SIZE:      /* fid -- size */
     tos = pfsize(tos, up);
     next;
 


### PR DESCRIPTION
Also, it doesn't seem to work.  Returns 2.

Cause unknown.  Still investigating.

spiffs.c:
```
size_t myspiffs_size( int fd ){
  int32_t curpos = SPIFFS_tell(&fs, (spiffs_file) fd);
  int32_t size = SPIFFS_lseek(&fs, (spiffs_file) fd, SPIFFS_SEEK_END, 0);
  (void) SPIFFS_lseek(&fs, (spiffs_file) fd, SPIFFS_SEEK_SET, curpos);
  return size;
}
```