### PR TITLE
ESP8266 TCP - add dns-gethostbyname

### DIFF
--- a/src/app/esp8266/lwip.c
+++ b/src/app/esp8266/lwip.c
@@ -6,6 +6,28 @@ extern cell *callback_up;
 #include "esp_stdint.h"
 #include "lwip/tcp.h"
 
+xt_t gethostbyname_forth_cb;
+void gethostbyname_cb(char *name, struct ip_addr *ipaddr, void *arg)
+{
+  cell *up = callback_up;
+  if (!gethostbyname_forth_cb) {
+    return;
+  }
+  spush(arg, up);
+  spush((cell)ipaddr, up);
+  spush((cell)name, up);
+
+  execute_xt(gethostbyname_forth_cb, up);
+}
+
+extern err_t dns_gethostbyname(const char *hostname, struct ip_addr *addr, void *found, void *callback_arg);
+
+err_t dns_gethostbyname1(char *hostname, struct ip_addr *ipaddr, xt_t callback, void *arg)
+{
+  gethostbyname_forth_cb = callback;
+  return dns_gethostbyname(hostname, ipaddr, gethostbyname_cb, arg);
+}
+
 cell tcp_write_sw(struct tcp_pcb *pcb, size_t len, uint8_t *adr)
 {
   return tcp_write(pcb, adr, len, 0);

--- a/src/app/esp8266/textend.c
+++ b/src/app/esp8266/textend.c
@@ -22,6 +22,7 @@ cell deep_sleep(cell us, cell type)
 #include "lwip/err.h"
 #include "lwip/pbuf.h"
 
+err_t dns_gethostbyname1(char *hostname, struct ip_addr *ipaddr, xt_t callback, void *arg);
 struct tcp_pcb *tcp_new(void);
 void tcp_arg(struct tcp_pcb *pcb, void* arg);
 struct tcp_pcb *tcp_listen_with_backlog(struct tcp_pcb *pcb, uint8_t backlog);
@@ -520,6 +521,8 @@ cell ((* const ccalls[])()) = {
 
   C(rtc_get_reset_reason)   //c reset-reason { -- i.reason }
   C(xthal_get_ccount)       //c xthal_get_ccount  { -- i.count }
+
+  C(dns_gethostbyname1)     //c dns-gethostbyname { a.arg i.xt a.ipaddr a.hostname -- i.stat }
 
   C(tcp_write_sw)           //c tcp-write  { a.adr i.len a.pcb -- i.stat }
   C(tcp_new)                //c tcp-new  { -- a.pcb }


### PR DESCRIPTION
For queries by name, returns `ERR_INPROGRESS`, and the callback is given address of IP address, or 0 if name was not found.

For queries where the name is a numeric IP address, returns `ERR_OK`, with IP filled in, and no callback.

An extern was used because the build was unhappy with `dns.h` and didn't have the patience to resolve it.

Test case, in station mode associated with an access point:

```
: ?.ipaddr  ( a.ip -- )  ?dup if  .ipaddr  else  ." NULL"  then  ;

: dns-cb  ( a.arg a.ip a.name -- )
   rot
   ." dns-cb arg " . cr
   swap
   ." dns-cb ip " ?.ipaddr cr
   ." dns-cb name " cscount type cr
;

create ip  4 allot  \ not used unless query is numeric

42 ' dns-cb ip c" google.com"            dns-gethostbyname . cr d# 1000 ms
43 ' dns-cb ip c" tooraweenah.com"       dns-gethostbyname . cr d# 1000 ms
44 ' dns-cb ip c" bogus.tooraweenah.com" dns-gethostbyname . cr d# 1000 ms
45 ' dns-cb ip c" 127.0.0.1"             dns-gethostbyname . cr ip ?.ipaddr cr
```