### PR TITLE
I2C drivers for af1271 mlx90614

### DIFF
--- a/src/app/esp8266/af1271.fth
+++ b/src/app/esp8266/af1271.fth
@@ -1,0 +1,87 @@
+\ Driver for Adafruit AF-1271 four digit seven segment display, based on
+\ Holtek HT16K33 28 SOP-A RAM Mapping 16*8 LED Controller Driver with keyscan
+
+$70 value ht-slave
+
+: ht-cmd  ( cmd -- )  ht-slave i2c-start-write drop i2c-stop  ;
+: ht-on  ( -- ) 21 ht-cmd  ;  \ turn on oscillator
+: ht-off  ( -- ) 20 ht-cmd  ;  \ turn on oscillator
+: ht-br!  ( brightness -- )  e0 or ht-cmd  ;  \ set brightness
+
+: leds-off    ( -- )  80 ht-cmd  ;
+: leds-on     ( -- )  81 ht-cmd  ;
+: leds-2hz    ( -- )  83 ht-cmd  ;
+: leds-1hz    ( -- )  85 ht-cmd  ;
+: leds-0.5hz  ( -- )  87 ht-cmd  ;
+
+: ram!  ( val pos -- )
+   ht-slave i2c-start-write abort" start write"
+   i2c-byte! drop
+   i2c-stop
+;
+
+: all-ram!  ( val -- )
+   0 ht-slave i2c-start-write abort" start write"  ( val )
+   10 0 do dup i2c-byte! drop loop drop          ( )
+   i2c-stop
+;
+
+: 0ram    0 all-ram!  ;
+: 1ram  $ff all-ram!  ;
+
+create leds  \ segment mapping; g f e d c b a
+3f c, 06 c, 5b c, 4f c, 66 c, 6d c, 7d c, 07 c,
+7f c, 6f c, 77 c, 7c c, 39 c, 5e c, 79 c, 71 c,  \ unused; a through f
+
+\ dots mapping; n/c n/c n/c right bottom-left bottom-right centre n/c
+: colon-on  2 4 ram!  ;
+: colon-off  0 4 ram!  ;
+
+0 value pos
+
+: leds-cr  0 to pos  ;
+
+: leds-next  ( -- )
+   pos 2+ to pos
+   pos 4  =  if  pos 2+ to pos  then
+   pos #10  =  if  leds-cr  then
+;
+
+: leds-emit  ( number -- )
+   $30 -  leds + c@  pos ram!
+   leds-next
+;
+
+: leds-type  ( adr len -- )
+   bounds  do  i c@ leds-emit  loop
+;
+
+: leds-spaces  ( n -- )
+   0 max 0 ?do
+      0 pos ram!
+      leds-next
+   loop
+;
+
+: leds.  ( number -- )
+   leds-cr  (.)  leds-type
+;
+
+: leds.r  ( number width -- )
+   leds-cr >r (.) r> over - leds-spaces leds-type
+;
+
+: af1271-init
+   ht-on
+   0ram
+   3 ht-br!
+   leds-on
+;
+
+: af1271-test
+   af1271-init
+   2 0 do  1ram  d# 100 ms  0ram  d# 400 ms  loop
+   push-decimal
+   #10000 0 do i 4 leds.r 1 ms loop
+   pop-base
+;

--- a/src/app/esp8266/mlx90614.fth
+++ b/src/app/esp8266/mlx90614.fth
@@ -1,0 +1,36 @@
+\ Driver for Melexis MLX90614 Non-Contact Infra Red Thermometer TO-39
+
+$5a value mlx-slave
+
+: mlx-w@  ( reg -- val )  mlx-slave 0 i2c-le-w@  ;
+
+\ read flags; bit 4 is power-on-reset (typical 150ms) active low
+: flags@  ( -- flags )  f0 mlx-w@  ;
+
+\ get raw data from ir sensor
+: raw@  ( -- b )  4 mlx-w@  ;
+
+\ get temperature ambient, in units of 0.02 degrees kelvin
+: ta@  ( -- TaK0.02 )  6 mlx-w@  ;
+
+\ get temperature object, in units of 0.02 degrees kelvin
+: to@  ( -- ToK0.02 )  7 mlx-w@  ;
+
+\ convert to millidegrees celcius
+: k>c  ( K0.02 -- mC )  #20  * #273150 -  ;
+
+\ format or print a millidegrees celcius value as degrees celcius
+: (.c)  ( mC -- $ )  push-decimal  <# u# u# u# '.' hold u#s u#> pop-base  ;
+: .c  ( mC -- )  (.c)  type space  ;
+
+\ print temperatures
+: .ambient  ta@  k>c  .c  ;
+: .object  to@  k>c  .c  ;
+
+: watch-temperature
+   begin
+      get-ticks .d  flags@ . raw@ . .ambient  .object  cr
+      d# 100 ms
+      key?
+   until
+;


### PR DESCRIPTION
* Adafruit AF-1271 four digit LED display, Holtek HT16K33,
* Melexis MLX90614 Non-Contact Infra Red Thermometer.