### PR TITLE
Clean EXTRA_CLEAN

### DIFF
--- a/src/app/embed-linux/targets.mk
+++ b/src/app/embed-linux/targets.mk
@@ -68,7 +68,8 @@ tdate.o: $(PLAT_OBJS) $(FORTH_OBJS)
 	@echo TCC $@
 	@$(TCC) -c tdate.c -o $@
 
-EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS) tdate.c version
+EXTRA_CLEAN += *.elf *.dump *.nm *.img tdate.c version
+EXTRA_CLEAN += $(FORTH_OBJS) $(PLAT_OBJS)
 
 PREFIX += CBP=$(realpath $(TOPDIR)/src)
 

--- a/src/app/esp32/targets.mk
+++ b/src/app/esp32/targets.mk
@@ -72,7 +72,8 @@ tdate.o: $(PLAT_OBJS) $(FORTH_OBJS)
 	@echo TCC $@
 	@$(TCC) -c tdate.c -o $@
 
-EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS) tdate.c version
+EXTRA_CLEAN += *.elf *.dump *.nm *.img tdate.c version
+EXTRA_CLEAN += $(FORTH_OBJS) $(PLAT_OBJS)
 
 PREFIX += CBP=$(realpath $(TOPDIR)/src)
 

--- a/src/app/esp8266/targets.mk
+++ b/src/app/esp8266/targets.mk
@@ -87,7 +87,8 @@ tdate.o: $(PLAT_OBJS) $(FORTH_OBJS)
 	@echo TCC $@
 	@$(TCC) -c tdate.c -o $@
 
-EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS)
+EXTRA_CLEAN += *.elf *.dump *.nm *.img tdate.c version
+EXTRA_CLEAN += $(FORTH_OBJS) $(PLAT_OBJS)
 
 PREFIX += CBP=$(realpath $(TOPDIR)/src)
 PREFIX += BP=$(realpath /c/Users/wmb/Documents/svn/openfirmware)

--- a/src/platform/arm-teensy3/targets.mk
+++ b/src/platform/arm-teensy3/targets.mk
@@ -78,4 +78,5 @@ tdate.o: $(PLAT_OBJS) $(FORTH_OBJS)
 	@echo TCC $@
 	@$(TCC) -c tdate.c -o $@
 
-EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS)
+EXTRA_CLEAN += *.map *.elf *.dump *.nm *.hex version tdate.c
+EXTRA_CLEAN += $(FORTH_OBJS) $(PLAT_OBJS)


### PR DESCRIPTION
* "make clean" was leaving files behind on my arm-teensy3 branch, reported by @jordanhubbard,
* remove some not-needed cleans of date.c, in embed-linux, esp32, arm-teensy3,
* wrap long lines.