### PR TITLE
arm-teensy3 - merge various changes

### DIFF
--- a/src/app/arm-teensy3/app.fth
+++ b/src/app/arm-teensy3/app.fth
@@ -3,26 +3,6 @@
 fl ../../lib/misc.fth
 fl ../../lib/dl.fth
 
-#0 ccall: spins       { i.nspins -- }
-#1 ccall: wfi         { -- }
-#2 ccall: get-msecs   { -- n }
-#3 ccall: a!          { i.val -- }
-#4 ccall: a@          { i.pin -- n }
-#5 ccall: p!          { i.val i.pin -- }
-#6 ccall: p@          { i.pin -- n }
-#7 ccall: m!          { i.mode i.pin -- }
-#8 ccall: get-usecs   { -- n }
-#9 ccall: delay       { n -- }
-#10 ccall: bye        { -- }
-#11 ccall: /nv        { -- n }
-#12 ccall: nv-base    { -- n }
-#13 ccall: nv-length  { -- n }
-#14 ccall: nv@        { i.adr -- i.val }
-#15 ccall: nv!        { i.val i.adr -- }
-#16 ccall: 'build-date   { -- a.value }
-#17 ccall: 'version      { -- a.value }
-
-fl ../../platform/arm-teensy3/watchdog.fth
 fl ../../platform/arm-teensy3/timer.fth
 fl ../../platform/arm-teensy3/pcr.fth
 fl ../../platform/arm-teensy3/i2c.fth

--- a/src/cforth/targets.mk
+++ b/src/cforth/targets.mk
@@ -116,7 +116,7 @@ meta: $(METAOBJS)
 forth: $(BASEOBJS) $(HOSTOBJS)
 	@echo MAKING FORTH
 	@echo CC $(HOSTOBJS) $(BASEOBJS) $(LIBS) -o $@
-	$(CC) $(CFLAGS) -o $@ $(HOSTOBJS) $(BASEOBJS) $(LIBS)
+	@$(CC) $(CFLAGS) -o $@ $(HOSTOBJS) $(BASEOBJS) $(LIBS)
 
 # main.o is the main() entry point for the self-contained applications above
 
@@ -156,11 +156,12 @@ date.o: $(PLAT_OBJS) $(FORTH_OBJS)
 # are used in the compilation of other object modules.
 
 init.x prims.h vars.h: forth.c
-	$(MAKE) makename
-	rm -f init.x prims.h vars.h
+	@$(MAKE) --no-print-directory makename
+	@rm -f init.x prims.h vars.h
 	@echo CPP $<
 	@$(CPP) -C -DMAKEPRIMS $(CONFIG) $< >forth.ip
-	./makename forth.ip
+	@echo MAKENAME
+	@./makename forth.ip
 
 # makename is a self-contained application whose purpose is to
 # extract various bits of information from the "forth.c" source

--- a/src/platform/arm-teensy3/analog.c
+++ b/src/platform/arm-teensy3/analog.c
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -10,10 +10,10 @@
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be 
+ * 1. The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  *
- * 2. If the Software is incorporated into a build system that allows 
+ * 2. If the Software is incorporated into a build system that allows
  * selection among a list of target devices, then similar target
  * devices manufactured by PJRC.COM must be included in the list of
  * target devices and selectable in the same manner.
@@ -347,15 +347,27 @@ void analogReadAveraging(unsigned int num)
 	} else if (num <= 4) {
 		num = 4;
 		ADC0_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(0);
+#ifdef HAS_KINETIS_ADC1
+		ADC1_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(0);
+#endif
 	} else if (num <= 8) {
 		num = 8;
 		ADC0_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(1);
+#ifdef HAS_KINETIS_ADC1
+		ADC1_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(1);
+#endif
 	} else if (num <= 16) {
 		num = 16;
 		ADC0_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(2);
+#ifdef HAS_KINETIS_ADC1
+		ADC1_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(2);
+#endif
 	} else {
 		num = 32;
 		ADC0_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(3);
+#ifdef HAS_KINETIS_ADC1
+		ADC1_SC3 = ADC_SC3_AVGE + ADC_SC3_AVGS(3);
+#endif
 	}
 	analog_num_average = num;
 }
@@ -501,7 +513,7 @@ startADC1:
 #endif
 }
 
-
+typedef int16_t __attribute__((__may_alias__)) aliased_int16_t;
 
 void analogWriteDAC0(int val)
 {
@@ -514,7 +526,8 @@ void analogWriteDAC0(int val)
 	}
 	if (val < 0) val = 0;  // TODO: saturate instruction?
 	else if (val > 4095) val = 4095;
-	*(int16_t *)&(DAC0_DAT0L) = val;
+
+	*(volatile aliased_int16_t *)&(DAC0_DAT0L) = val;
 #elif defined(__MKL26Z64__)
 	SIM_SCGC6 |= SIM_SCGC6_DAC0;
 	if (analog_reference_internal == 0) {
@@ -526,7 +539,8 @@ void analogWriteDAC0(int val)
 	}
 	if (val < 0) val = 0;
 	else if (val > 4095) val = 4095;
-	*(int16_t *)&(DAC0_DAT0L) = val;
+
+	*(volatile aliased_int16_t *)&(DAC0_DAT0L) = val;
 #endif
 }
 
@@ -542,7 +556,8 @@ void analogWriteDAC1(int val)
 	}
 	if (val < 0) val = 0;  // TODO: saturate instruction?
 	else if (val > 4095) val = 4095;
-	*(int16_t *)&(DAC1_DAT0L) = val;
+
+	*(volatile aliased_int16_t *)&(DAC1_DAT0L) = val;
 }
 #endif
 

--- a/src/platform/arm-teensy3/avr_functions.h
+++ b/src/platform/arm-teensy3/avr_functions.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/platform/arm-teensy3/core_pins.h
+++ b/src/platform/arm-teensy3/core_pins.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -1389,6 +1389,86 @@
 #endif
 
 
+#if defined(__MK20DX128__)
+#define CORE_FTM0_CH0_PIN	22
+#define CORE_FTM0_CH1_PIN	23
+#define CORE_FTM0_CH2_PIN	 9
+#define CORE_FTM0_CH3_PIN	10
+#define CORE_FTM0_CH4_PIN	 6
+#define CORE_FTM0_CH5_PIN	20
+#define CORE_FTM0_CH6_PIN	21
+#define CORE_FTM0_CH7_PIN	 5
+#define CORE_FTM1_CH0_PIN	 3
+#define CORE_FTM1_CH1_PIN	 4
+#elif defined(__MK20DX256__)
+#define CORE_FTM0_CH0_PIN	22
+#define CORE_FTM0_CH1_PIN	23
+#define CORE_FTM0_CH2_PIN	 9
+#define CORE_FTM0_CH3_PIN	10
+#define CORE_FTM0_CH4_PIN	 6
+#define CORE_FTM0_CH5_PIN	20
+#define CORE_FTM0_CH6_PIN	21
+#define CORE_FTM0_CH7_PIN	 5
+#define CORE_FTM1_CH0_PIN	 3
+#define CORE_FTM1_CH1_PIN	 4
+#define CORE_FTM2_CH0_PIN	32
+#define CORE_FTM2_CH1_PIN	25
+#elif defined(__MKL26Z64__)
+#define CORE_TPM0_CH0_PIN	22
+#define CORE_TPM0_CH1_PIN	23
+#define CORE_TPM0_CH2_PIN	 9
+#define CORE_TPM0_CH3_PIN	10
+#define CORE_TPM0_CH4_PIN	 6
+#define CORE_TPM0_CH5_PIN	20
+#define CORE_TPM1_CH0_PIN	16
+#define CORE_TPM1_CH1_PIN	17
+#define CORE_TPM2_CH0_PIN	 3
+#define CORE_TPM2_CH1_PIN	 4
+#elif defined(__MK64FX512__)
+#define CORE_FTM0_CH0_PIN	22
+#define CORE_FTM0_CH1_PIN	23
+#define CORE_FTM0_CH2_PIN	 9
+#define CORE_FTM0_CH3_PIN	10
+#define CORE_FTM0_CH4_PIN	 6
+#define CORE_FTM0_CH5_PIN	20
+#define CORE_FTM0_CH6_PIN	21
+#define CORE_FTM0_CH7_PIN	 5
+#define CORE_FTM1_CH0_PIN	 3
+#define CORE_FTM1_CH1_PIN	 4
+#define CORE_FTM2_CH0_PIN	29
+#define CORE_FTM2_CH1_PIN	30
+#define CORE_FTM3_CH0_PIN	 2
+#define CORE_FTM3_CH1_PIN	14
+#define CORE_FTM3_CH2_PIN	 7
+#define CORE_FTM3_CH3_PIN	 8
+#define CORE_FTM3_CH4_PIN	35
+#define CORE_FTM3_CH5_PIN	36
+#define CORE_FTM3_CH6_PIN	37
+#define CORE_FTM3_CH7_PIN	38
+#elif defined(__MK66FX1M0__)
+#define CORE_FTM0_CH0_PIN	22
+#define CORE_FTM0_CH1_PIN	23
+#define CORE_FTM0_CH2_PIN	 9
+#define CORE_FTM0_CH3_PIN	10
+#define CORE_FTM0_CH4_PIN	 6
+#define CORE_FTM0_CH5_PIN	20
+#define CORE_FTM0_CH6_PIN	21
+#define CORE_FTM0_CH7_PIN	 5
+#define CORE_FTM1_CH0_PIN	 3
+#define CORE_FTM1_CH1_PIN	 4
+#define CORE_FTM2_CH0_PIN	29
+#define CORE_FTM2_CH1_PIN	30
+#define CORE_FTM3_CH0_PIN	 2
+#define CORE_FTM3_CH1_PIN	14
+#define CORE_FTM3_CH2_PIN	 7
+#define CORE_FTM3_CH3_PIN	 8
+#define CORE_FTM3_CH4_PIN	35
+#define CORE_FTM3_CH5_PIN	36
+#define CORE_FTM3_CH6_PIN	37
+#define CORE_FTM3_CH7_PIN	38
+#define CORE_TPM1_CH0_PIN	16
+#define CORE_TPM1_CH1_PIN	17
+#endif
 
 
 #ifdef __cplusplus
@@ -1838,8 +1918,8 @@ static inline uint8_t digitalReadFast(uint8_t pin)
 void pinMode(uint8_t pin, uint8_t mode);
 void init_pins(void);
 void analogWrite(uint8_t pin, int val);
-void analogWriteRes(uint32_t bits);
-static inline void analogWriteResolution(uint32_t bits) { analogWriteRes(bits); }
+uint32_t analogWriteRes(uint32_t bits);
+static inline uint32_t analogWriteResolution(uint32_t bits) { return analogWriteRes(bits); }
 void analogWriteFrequency(uint8_t pin, float frequency);
 void analogWriteDAC0(int val);
 void analogWriteDAC1(int val);

--- a/src/platform/arm-teensy3/eeprom.c
+++ b/src/platform/arm-teensy3/eeprom.c
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2016 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/platform/arm-teensy3/kinetis.h
+++ b/src/platform/arm-teensy3/kinetis.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -479,8 +479,8 @@ enum IRQ_NUMBER_t {
 #define DMAMUX_SOURCE_I2S0_TX		13
 #define DMAMUX_SOURCE_SPI0_RX		14
 #define DMAMUX_SOURCE_SPI0_TX		15
-#define DMAMUX_SOURCE_SPI1_RX		16
-#define DMAMUX_SOURCE_SPI1_TX		17
+#define DMAMUX_SOURCE_SPI1		16
+#define DMAMUX_SOURCE_SPI2		17
 #define DMAMUX_SOURCE_I2C0		18
 #define DMAMUX_SOURCE_I2C1		19
 #define DMAMUX_SOURCE_I2C2		19
@@ -545,7 +545,7 @@ enum IRQ_NUMBER_t {
 #define HAS_KINETIS_I2C1_STOPF
 #define HAS_KINETIS_I2C2
 #define HAS_KINETIS_I2C2_STOPF
-#define HAS_KINETIS_LLWU_32CH
+#define HAS_KINETIS_LLWU_16CH
 #define HAS_KINETIS_MPU
 #define HAS_KINETIS_ADC0
 #define HAS_KINETIS_ADC1
@@ -909,6 +909,9 @@ enum IRQ_NUMBER_t {
 #define PORTA_GPCLR		(*(volatile uint32_t *)0x40049080) // Global Pin Control Low Register
 #define PORTA_GPCHR		(*(volatile uint32_t *)0x40049084) // Global Pin Control High Register
 #define PORTA_ISFR		(*(volatile uint32_t *)0x400490A0) // Interrupt Status Flag Register
+#define PORTA_DFER		(*(volatile uint32_t *)0x400490C0) // Digital Filter Enable
+#define PORTA_DFCR		(*(volatile uint32_t *)0x400490C4) // Digital Filter Clock
+#define PORTA_DFWR		(*(volatile uint32_t *)0x400490C8) // Digital Filter Width
 #define PORTB_PCR0		(*(volatile uint32_t *)0x4004A000) // Pin Control Register n
 #define PORTB_PCR1		(*(volatile uint32_t *)0x4004A004) // Pin Control Register n
 #define PORTB_PCR2		(*(volatile uint32_t *)0x4004A008) // Pin Control Register n
@@ -944,6 +947,9 @@ enum IRQ_NUMBER_t {
 #define PORTB_GPCLR		(*(volatile uint32_t *)0x4004A080) // Global Pin Control Low Register
 #define PORTB_GPCHR		(*(volatile uint32_t *)0x4004A084) // Global Pin Control High Register
 #define PORTB_ISFR		(*(volatile uint32_t *)0x4004A0A0) // Interrupt Status Flag Register
+#define PORTB_DFER		(*(volatile uint32_t *)0x4004A0C0) // Digital Filter Enable
+#define PORTB_DFCR		(*(volatile uint32_t *)0x4004A0C4) // Digital Filter Clock
+#define PORTB_DFWR		(*(volatile uint32_t *)0x4004A0C8) // Digital Filter Width
 #define PORTC_PCR0		(*(volatile uint32_t *)0x4004B000) // Pin Control Register n
 #define PORTC_PCR1		(*(volatile uint32_t *)0x4004B004) // Pin Control Register n
 #define PORTC_PCR2		(*(volatile uint32_t *)0x4004B008) // Pin Control Register n
@@ -979,6 +985,9 @@ enum IRQ_NUMBER_t {
 #define PORTC_GPCLR		(*(volatile uint32_t *)0x4004B080) // Global Pin Control Low Register
 #define PORTC_GPCHR		(*(volatile uint32_t *)0x4004B084) // Global Pin Control High Register
 #define PORTC_ISFR		(*(volatile uint32_t *)0x4004B0A0) // Interrupt Status Flag Register
+#define PORTC_DFER		(*(volatile uint32_t *)0x4004B0C0) // Digital Filter Enable
+#define PORTC_DFCR		(*(volatile uint32_t *)0x4004B0C4) // Digital Filter Clock
+#define PORTC_DFWR		(*(volatile uint32_t *)0x4004B0C8) // Digital Filter Width
 #define PORTD_PCR0		(*(volatile uint32_t *)0x4004C000) // Pin Control Register n
 #define PORTD_PCR1		(*(volatile uint32_t *)0x4004C004) // Pin Control Register n
 #define PORTD_PCR2		(*(volatile uint32_t *)0x4004C008) // Pin Control Register n
@@ -1014,6 +1023,9 @@ enum IRQ_NUMBER_t {
 #define PORTD_GPCLR		(*(volatile uint32_t *)0x4004C080) // Global Pin Control Low Register
 #define PORTD_GPCHR		(*(volatile uint32_t *)0x4004C084) // Global Pin Control High Register
 #define PORTD_ISFR		(*(volatile uint32_t *)0x4004C0A0) // Interrupt Status Flag Register
+#define PORTD_DFER		(*(volatile uint32_t *)0x4004C0C0) // Digital Filter Enable
+#define PORTD_DFCR		(*(volatile uint32_t *)0x4004C0C4) // Digital Filter Clock
+#define PORTD_DFWR		(*(volatile uint32_t *)0x4004C0C8) // Digital Filter Width
 #define PORTE_PCR0		(*(volatile uint32_t *)0x4004D000) // Pin Control Register n
 #define PORTE_PCR1		(*(volatile uint32_t *)0x4004D004) // Pin Control Register n
 #define PORTE_PCR2		(*(volatile uint32_t *)0x4004D008) // Pin Control Register n
@@ -1049,6 +1061,9 @@ enum IRQ_NUMBER_t {
 #define PORTE_GPCLR		(*(volatile uint32_t *)0x4004D080) // Global Pin Control Low Register
 #define PORTE_GPCHR		(*(volatile uint32_t *)0x4004D084) // Global Pin Control High Register
 #define PORTE_ISFR		(*(volatile uint32_t *)0x4004D0A0) // Interrupt Status Flag Register
+#define PORTE_DFER		(*(volatile uint32_t *)0x4004D0C0) // Digital Filter Enable
+#define PORTE_DFCR		(*(volatile uint32_t *)0x4004D0C4) // Digital Filter Clock
+#define PORTE_DFWR		(*(volatile uint32_t *)0x4004D0C8) // Digital Filter Width
 
 // System Integration Module (SIM)
 
@@ -1294,6 +1309,15 @@ enum IRQ_NUMBER_t {
 #define SMC_VLLSCTRL		(*(volatile uint8_t  *)0x4007E002) // VLLS Control Register
 #define SMC_VLLSCTRL_PORPO		((uint8_t)0x20)			// POR Power Option
 #define SMC_VLLSCTRL_VLLSM(n)		((uint8_t)((n) & 0x07))		// VLLS Mode Control
+
+#if defined(__MK66FX1M0__)
+#define SMC_STOPCTRL			SMC_VLLSCTRL // Stop Control Register (compatible to SMC_VLLSCTRL)
+#define SMC_STOPCTRL_PSTOPO(n)	((uint8_t)(((n) & 0x03) << 6)) 		// Partial Stop Option
+#define SMC_STOPCTRL_PORPO		SMC_VLLSCTRL_PORPO		// POR Power Option
+#define SMC_STOPCTRL_RAM2PO		((uint8_t)0x10)			// RAM2 Power Option
+#define SMC_STOPCTRL_LLSM(n)		SMC_VLLSCTRL_VLLSM(n)		// VLLS Mode Control
+#endif
+
 #define SMC_PMSTAT		(*(volatile uint8_t  *)0x4007E003) // Power Mode Status Register
 #define SMC_PMSTAT_RUN			((uint8_t)0x01)			// Current power mode is RUN
 #define SMC_PMSTAT_STOP			((uint8_t)0x02)			// Current power mode is STOP
@@ -1327,6 +1351,10 @@ enum IRQ_NUMBER_t {
 
 #if defined(HAS_KINETIS_LLWU_32CH)
 #define LLWU_PE1		(*(volatile uint8_t  *)0x4007C000) // LLWU Pin Enable 1 register
+#define LLWU_PE_WUPE_PIN_DISABLE	((uint8_t)0x00)		// Disable pin as wakeup pin
+#define LLWU_PE_WUPE_PIN_RISING		((uint8_t)0x01)		// Enable pin rising edge detect
+#define LLWU_PE_WUPE_PIN_FALLING	((uint8_t)0x10)		// Enable pin falling edge detect
+#define LLWU_PE_WUPE_PIN_ANY		((uint8_t)0x11)		// Enable pin with any change detect
 #define LLWU_PE1_WUPE0(n)       ((uint8_t)((n) & 0x03)) // Wakeup Pin Enable For LLWU_P0
 #define LLWU_PE1_WUPE1(n)       ((uint8_t)(((n) & 0x03) << 2)) // Wakeup Pin Enable For LLWU_P1
 #define LLWU_PE1_WUPE2(n)       ((uint8_t)(((n) & 0x03) << 4)) // Wakeup Pin Enable For LLWU_P2
@@ -1426,6 +1454,10 @@ enum IRQ_NUMBER_t {
 #define LLWU_FILT4		(*(volatile uint8_t  *)0x4007C011) // LLWU Pin Filter 4 register
 #elif defined(HAS_KINETIS_LLWU_16CH)
 #define LLWU_PE1		(*(volatile uint8_t  *)0x4007C000) // LLWU Pin Enable 1 register
+#define LLWU_PE_WUPE_PIN_DISABLE	((uint8_t)0x00)		// Disable pin as wakeup pin
+#define LLWU_PE_WUPE_PIN_RISING		((uint8_t)0x01)		// Enable pin rising edge detect
+#define LLWU_PE_WUPE_PIN_FALLING	((uint8_t)0x10)		// Enable pin falling edge detect
+#define LLWU_PE_WUPE_PIN_ANY		((uint8_t)0x11)		// Enable pin with any change detect
 #define LLWU_PE1_WUPE0(n)       ((uint8_t)((n) & 0x03)) // Wakeup Pin Enable For LLWU_P0
 #define LLWU_PE1_WUPE1(n)       ((uint8_t)(((n) & 0x03) << 2)) // Wakeup Pin Enable For LLWU_P1
 #define LLWU_PE1_WUPE2(n)       ((uint8_t)(((n) & 0x03) << 4)) // Wakeup Pin Enable For LLWU_P2
@@ -2878,6 +2910,9 @@ typedef struct {
 #define DAC0_DAT14L		(*(volatile uint8_t  *)0x400CC01C) // DAC Data Low Register
 #define DAC0_DAT15L		(*(volatile uint8_t  *)0x400CC01E) // DAC Data Low Register
 #define DAC0_SR			(*(volatile uint8_t  *)0x400CC020) // DAC Status Register
+#define DAC_SR_DACBFWMF			0x04				// Buffer Watermark Flag
+#define DAC_SR_DACBFRTF			0x02				// Pointer Top Position Flag
+#define DAC_SR_DACBFRBF			0x01				// Pointer Bottom Position Flag
 #define DAC0_C0			(*(volatile uint8_t  *)0x400CC021) // DAC Control Register
 #define DAC_C0_DACEN			0x80				// DAC Enable
 #define DAC_C0_DACRFS			0x40				// DAC Reference Select
@@ -3031,6 +3066,8 @@ typedef struct {
 #define PDB0_CH1DLY0		(*(volatile uint32_t *)0x40036040) // Channel 1 Delay 0 Register
 #define PDB0_CH1DLY1		(*(volatile uint32_t *)0x40036044) // Channel 1 Delay 1 Register
 #define PDB0_DACINTC0		(*(volatile uint32_t *)0x40036150) // DAC Interval Trigger n Control Register
+#define PDB_DACINTC_EXT			0x02			// External Trigger Input Enable
+#define PDB_DACINTC_TOE			0x01			// Interval Trigger Enable
 #define PDB0_DACINT0		(*(volatile uint32_t *)0x40036154) // DAC Interval n Register
 #define PDB0_DACINTC1		(*(volatile uint32_t *)0x40036158) // DAC Interval Trigger n Control register
 #define PDB0_DACINT1		(*(volatile uint32_t *)0x4003615C) // DAC Interval n register
@@ -3547,6 +3584,12 @@ typedef struct {
 #define RTC_SR_TIF			((uint32_t)0x00000001)		//
 #define RTC_LR			(*(volatile uint32_t *)0x4003D018) // RTC Lock Register
 #define RTC_IER			(*(volatile uint32_t *)0x4003D01C) // RTC Interrupt Enable Register
+#define RTC_IER_WPON		((uint32_t)0x00000080)		// RTC Wakeup Pin
+#define RTC_IER_TSIE		((uint32_t)0x00000010)		// RTC Time Seconds Interrupt
+#define RTC_IER_MOIE		((uint32_t)0x00000008)		// RTC Monotonic Overflow Interrupt
+#define RTC_IER_TAIE		((uint32_t)0x00000004)		// RTC Time Alarm Interrupt
+#define RTC_IER_TOIE		((uint32_t)0x00000002)		// RTC Overflow Interrupt
+#define RTC_IER_TIIE		((uint32_t)0x00000001)		// RTC Time Invalid Interrupt
 #define RTC_WAR			(*(volatile uint32_t *)0x4003D800) // RTC Write Access Register
 #define RTC_RAR			(*(volatile uint32_t *)0x4003D804) // RTC Read Access Register
 

--- a/src/platform/arm-teensy3/mk20dx128.h
+++ b/src/platform/arm-teensy3/mk20dx128.h
@@ -1,3 +1,5 @@
+// This header file is in the public domain.
+
 #ifndef _mk20dx128_h_
 #define _mk20dx128_h_
 #include "kinetis.h"  // mk20dx128.h renamed to kinetis.h

--- a/src/platform/arm-teensy3/mk20dx256.ld
+++ b/src/platform/arm-teensy3/mk20dx256.ld
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -10,10 +10,10 @@
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be 
+ * 1. The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
  *
- * 2. If the Software is incorporated into a build system that allows 
+ * 2. If the Software is incorporated into a build system that allows
  * selection among a list of target devices, then similar target
  * devices manufactured by PJRC.COM must be included in the list of
  * target devices and selectable in the same manner.
@@ -33,41 +33,6 @@ MEMORY
 	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 256K
 	RAM  (rwx) : ORIGIN = 0x1FFF8000, LENGTH = 64K
 }
-
-
-/* INCLUDE common.ld */
-
-
-/* Teensyduino Core Library
- * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * 1. The above copyright notice and this permission notice shall be 
- * included in all copies or substantial portions of the Software.
- *
- * 2. If the Software is incorporated into a build system that allows 
- * selection among a list of target devices, then similar target
- * devices manufactured by PJRC.COM must be included in the list of
- * target devices and selectable in the same manner.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 
 
 SECTIONS
@@ -149,12 +114,14 @@ teensy31-blinky-bare-metal uses -O0 which gives 0x02c2
 
 	.bss : {
 		. = ALIGN(4);
-		_sbss = .; 
+		_sbss = .;
+		__bss_start__ = .;
 		*(.bss*)
 		*(COMMON)
 		. = ALIGN(4);
 		_ebss = .;
 		__bss_end = .;
+		__bss_end__ = .;
 	} > RAM
 
 	_estack = ORIGIN(RAM) + LENGTH(RAM);

--- a/src/platform/arm-teensy3/pins_arduino.h
+++ b/src/platform/arm-teensy3/pins_arduino.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/platform/arm-teensy3/ser_print.h
+++ b/src/platform/arm-teensy3/ser_print.h
@@ -1,3 +1,32 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 #ifdef __cplusplus
 extern "C"{

--- a/src/platform/arm-teensy3/targets.mk
+++ b/src/platform/arm-teensy3/targets.mk
@@ -65,13 +65,13 @@ app.elf: $(PLAT_OBJS) $(FORTH_OBJS) tdate.o
 
 # This rule loads the hex file to the module
 burn: app.hex
-	./teensy_loader_cli -w -mmcu=mk20dx128 app.hex
+	teensy_loader_cli -w -mmcu=mk20dx128 app.hex
 
 # This rule builds a date stamp object that you can include in the image
 # if you wish.
 
 tdate.o: $(PLAT_OBJS) $(FORTH_OBJS)
-	@(echo "`git rev-parse --verify --short HEAD`" || echo UNKNOWN) >version
+	@(echo "`git rev-parse --verify --short HEAD``if git diff-index --exit-code --name-only HEAD >/dev/null; then echo '-dirty'; fi`" || echo UNKNOWN) >version
 	@echo 'const char version[] = "'`cat version`'";' >tdate.c
 	@echo 'const char build_date[] = "'`date --utc +%F\ %R`'";' >>tdate.c
 	@cat tdate.c

--- a/src/platform/arm-teensy3/textend.c
+++ b/src/platform/arm-teensy3/textend.c
@@ -1,15 +1,14 @@
 // Edit this file to include C routines that can be called as Forth words.
 // See "ccalls" below.
 
-// This is the only thing that we need from forth.h
-#define cell long
+#include "forth.h"
 
 // Prototypes
 
 cell get_msecs();
 cell wfi();
 cell spins();
-cell analogWriteDAC0();
+cell analogWrite();
 cell analogRead();
 cell digitalWrite();
 cell digitalRead();
@@ -22,6 +21,15 @@ cell eeprom_base();
 cell eeprom_length();
 cell eeprom_read_byte();
 cell eeprom_write_byte();
+unsigned long rtc_get(void);
+void rtc_set(unsigned long t);
+void rtc_compensate(int adjust);
+void console_uart_on();
+void console_uart_off();
+int console_uart();
+void console_usb_on();
+void console_usb_off();
+int console_usb();
 
 cell version_adr(void)
 {
@@ -35,35 +43,53 @@ cell build_date_adr(void)
     return (cell)build_date;
 }
 
+/*
+ * "Watchdog Unlock register (WDOG_UNLOCK)"
+ * "Writing the unlock sequence values to this register to makes the
+ * watchdog write-once registers writable again.  The required unlock
+ * sequence is 0xC520 followed by 0xD928 within 20 bus clock cycles.
+ * A valid unlock sequence opens a window equal in length to the WCT
+ * within which you can update the registers.  Writing a value other
+ * than the above mentioned sequence or if the sequence is longer than
+ * 20 bus cycles, resets the system or if IRQRSTEN is set, it
+ * interrupts and then resets the system.  The unlock sequence is
+ * effective only if ALLOWUPDATE is set."
+ * -- K20P64M72SF1RM.pdf 23.7.8 page 478
+ */
+#define WDOG_UNLOCK (*(volatile uint32_t *)0x4005200e)
+
+void restart(void)
+{
+  WDOG_UNLOCK = 0; /* force system reset */
+}
+
 cell ((* const ccalls[])()) = {
-
-    (cell (*)())spins,            // Entry # 0
-    (cell (*)())wfi,              // Entry # 1
-    (cell (*)())get_msecs,        // Entry # 2
-    (cell (*)())analogWriteDAC0,  // Entry # 3
-    (cell (*)())analogRead,       // Entry # 4
-    (cell (*)())digitalWrite,     // Entry # 5
-    (cell (*)())digitalRead,      // Entry # 6
-    (cell (*)())pinMode,          // Entry # 7
-    (cell (*)())micros,           // Entry # 8
-    (cell (*)())delay,            // Entry # 9  // fixme: hangs
-    (cell (*)())_reboot_Teensyduino_, // Entry # 10
-    (cell (*)())eeprom_size,
-    (cell (*)())eeprom_base,
-    (cell (*)())eeprom_length,
-    (cell (*)())eeprom_read_byte,
-    (cell (*)())eeprom_write_byte,
-    (cell (*)())build_date_adr,
-    (cell (*)())version_adr,
+        C(spins)                //c spins               { i.nspins -- }
+        C(wfi)                  //c wfi                 { -- }
+        C(get_msecs)            //c get-msecs           { -- n }
+        C(analogWrite)          //c a!                  { i.val i.pin -- }
+        C(analogRead)           //c a@                  { i.pin -- n }
+        C(digitalWrite)         //c p!                  { i.val i.pin -- }
+        C(digitalRead)          //c p@                  { i.pin -- n }
+        C(pinMode)              //c m!                  { i.mode i.pin -- }
+        C(micros)               //c get-usecs           { -- n }
+        C(delay)                //c ms                  { i.#ms -- }
+        C(eeprom_size)          //c /nv                 { -- n }
+        C(eeprom_base)          //c nv-base             { -- n }
+        C(eeprom_length)        //c nv-length           { -- n }
+        C(eeprom_read_byte)     //c nv@                 { i.adr -- i.val }
+        C(eeprom_write_byte)    //c nv!                 { i.val i.adr -- }
+        C(build_date_adr)       //c 'build-date         { -- a.value }
+        C(version_adr)          //c 'version            { -- a.value }
+        C(rtc_get)              //c rtc@                { -- i.val }
+        C(rtc_set)              //c rtc!                { i.val -- }
+        C(rtc_compensate)       //c rtc_compensate      { i.adjust -- }
+        C(console_uart)         //c uart?               { -- i.bytes }
+        C(console_uart_on)      //c uart-on             { -- }
+        C(console_uart_off)     //c uart-off            { -- }
+        C(console_usb)          //c usb?                { -- i.bytes }
+        C(console_usb_on)       //c usb-on              { -- }
+        C(console_usb_off)      //c usb-off             { -- }
+        C(_reboot_Teensyduino_) //c reflash             { -- }
+        C(restart)              //c restart             { -- }
 };
-
-// Forth words to call the above routines may be created by:
-//
-//  system also
-//  0 ccall: sum      { i.a i.b -- i.sum }
-//  1 ccall: byterev  { s.in -- s.out }
-//
-// and could be used as follows:
-//
-//  5 6 sum .
-//  p" hello"  byterev  count type

--- a/src/platform/arm-teensy3/tmain.c
+++ b/src/platform/arm-teensy3/tmain.c
@@ -4,9 +4,10 @@ main()
 {
     void *up;
 
+    init_uart();
     init_io();   // Perform platform-specific initialization
 
     up = (void *)init_forth();
     execute_word("app", up);  // Call the top-level application word
-//    execute_word("quit", up);  // Call the Forth text interpreter
+    restart(); // On bye, restart rather than hang
 }

--- a/src/platform/arm-teensy3/usb_desc.c
+++ b/src/platform/arm-teensy3/usb_desc.c
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -218,6 +218,7 @@ static uint8_t mouse_report_desc[] = {
 #endif
 
 #ifdef JOYSTICK_INTERFACE
+#if JOYSTICK_SIZE == 12
 static uint8_t joystick_report_desc[] = {
         0x05, 0x01,                     // Usage Page (Generic Desktop)
         0x09, 0x04,                     // Usage (Joystick)
@@ -262,7 +263,73 @@ static uint8_t joystick_report_desc[] = {
         0x81, 0x02,                     //   Input (variable,absolute)
         0xC0                            // End Collection
 };
-#endif
+#elif JOYSTICK_SIZE == 64
+// extreme joystick  (to use this, edit JOYSTICK_SIZE to 64 in usb_desc.h)
+//  128 buttons   16
+//    6 axes      12
+//   17 sliders   34
+//    4 pov        2
+static uint8_t joystick_report_desc[] = {
+        0x05, 0x01,                     // Usage Page (Generic Desktop)
+        0x09, 0x04,                     // Usage (Joystick)
+        0xA1, 0x01,                     // Collection (Application)
+        0x15, 0x00,                     // Logical Minimum (0)
+        0x25, 0x01,                     // Logical Maximum (1)
+        0x75, 0x01,                     // Report Size (1)
+        0x95, 0x80,                     // Report Count (128)
+        0x05, 0x09,                     // Usage Page (Button)
+        0x19, 0x01,                     // Usage Minimum (Button #1)
+        0x29, 0x80,                     // Usage Maximum (Button #128)
+        0x81, 0x02,                     // Input (variable,absolute)
+        0x05, 0x01,                     // Usage Page (Generic Desktop)
+        0x09, 0x01,                     // Usage (Pointer)
+        0xA1, 0x00,                     // Collection ()
+        0x15, 0x00,                     // Logical Minimum (0)
+        0x27, 0xFF, 0xFF, 0, 0,         // Logical Maximum (65535)
+        0x75, 0x10,                     // Report Size (16)
+        0x95, 23,                       // Report Count (23)
+        0x09, 0x30,                     // Usage (X)
+        0x09, 0x31,                     // Usage (Y)
+        0x09, 0x32,                     // Usage (Z)
+        0x09, 0x33,                     // Usage (Rx)
+        0x09, 0x34,                     // Usage (Ry)
+        0x09, 0x35,                     // Usage (Rz)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x09, 0x36,                     // Usage (Slider)
+        0x81, 0x02,                     // Input (variable,absolute)
+        0xC0,                           // End Collection
+        0x15, 0x00,                     // Logical Minimum (0)
+        0x25, 0x07,                     // Logical Maximum (7)
+        0x35, 0x00,                     // Physical Minimum (0)
+        0x46, 0x3B, 0x01,               // Physical Maximum (315)
+        0x75, 0x04,                     // Report Size (4)
+        0x95, 0x04,                     // Report Count (4)
+        0x65, 0x14,                     // Unit (20)
+        0x05, 0x01,                     // Usage Page (Generic Desktop)
+        0x09, 0x39,                     // Usage (Hat switch)
+        0x09, 0x39,                     // Usage (Hat switch)
+        0x09, 0x39,                     // Usage (Hat switch)
+        0x09, 0x39,                     // Usage (Hat switch)
+        0x81, 0x42,                     // Input (variable,absolute,null_state)
+        0xC0                            // End Collection
+};
+#endif // JOYSTICK_SIZE
+#endif // JOYSTICK_INTERFACE
 
 #ifdef MULTITOUCH_INTERFACE
 // https://forum.pjrc.com/threads/32331-USB-HID-Touchscreen-support-needed
@@ -876,7 +943,7 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
         0x06,                                   // bInterfaceClass (0x06 = still image)
         0x01,                                   // bInterfaceSubClass
         0x01,                                   // bInterfaceProtocol
-        0,                                      // iInterface
+        4,                                      // iInterface
         // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
         7,                                      // bLength
         5,                                      // bDescriptorType
@@ -1064,7 +1131,7 @@ static uint8_t config_descriptor[CONFIG_DESC_SIZE] = {
 	9, 					// bLength
 	5, 					// bDescriptorType, 5 = ENDPOINT_DESCRIPTOR
 	AUDIO_TX_ENDPOINT | 0x80,		// bEndpointAddress
-	0x05, 					// bmAttributes = isochronous, asynchronous
+	0x09, 					// bmAttributes = isochronous, adaptive
 	LSB(AUDIO_TX_SIZE), MSB(AUDIO_TX_SIZE),	// wMaxPacketSize
 	1,			 		// bInterval, 1 = every frame
 	0,					// bRefresh
@@ -1223,6 +1290,13 @@ struct usb_string_descriptor_struct usb_string_serial_number_default = {
         3,
         {0,0,0,0,0,0,0,0,0,0}
 };
+#ifdef MTP_INTERFACE
+struct usb_string_descriptor_struct usb_string_mtp = {
+	2 + 3 * 2,
+	3,
+	{'M','T','P'}
+};
+#endif
 
 void usb_init_serialnumber(void)
 {
@@ -1300,6 +1374,9 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
 #ifdef MULTITOUCH_INTERFACE
         {0x2200, MULTITOUCH_INTERFACE, multitouch_report_desc, sizeof(multitouch_report_desc)},
         {0x2100, MULTITOUCH_INTERFACE, config_descriptor+MULTITOUCH_HID_DESC_OFFSET, 9},
+#endif
+#ifdef MTP_INTERFACE
+	{0x0304, 0x0409, (const uint8_t *)&usb_string_mtp, 0},
 #endif
         {0x0300, 0x0000, (const uint8_t *)&string0, 0},
         {0x0301, 0x0409, (const uint8_t *)&usb_string_manufacturer_name, 0},

--- a/src/platform/arm-teensy3/usb_desc.h
+++ b/src/platform/arm-teensy3/usb_desc.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -203,7 +203,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MOUSE_INTERVAL        1
   #define JOYSTICK_INTERFACE    3	// Joystick
   #define JOYSTICK_ENDPOINT     4
-  #define JOYSTICK_SIZE         16
+  #define JOYSTICK_SIZE         12	//  12 = normal, 64 = extreme joystick
   #define JOYSTICK_INTERVAL     2
   #define ENDPOINT1_CONFIG	ENDPOINT_TRANSIMIT_ONLY
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_ONLY
@@ -249,7 +249,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MOUSE_INTERVAL        2
   #define JOYSTICK_INTERFACE    4	// Joystick
   #define JOYSTICK_ENDPOINT     6
-  #define JOYSTICK_SIZE         16
+  #define JOYSTICK_SIZE         12	//  12 = normal, 64 = extreme joystick
   #define JOYSTICK_INTERVAL     1
   #define ENDPOINT1_CONFIG	ENDPOINT_TRANSIMIT_ONLY
   #define ENDPOINT2_CONFIG	ENDPOINT_TRANSIMIT_ONLY
@@ -484,7 +484,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define SEREMU_RX_INTERVAL    2
   #define JOYSTICK_INTERFACE    2	// Joystick
   #define JOYSTICK_ENDPOINT     5
-  #define JOYSTICK_SIZE         16
+  #define JOYSTICK_SIZE         12	//  12 = normal, 64 = extreme joystick
   #define JOYSTICK_INTERVAL     1
   #define ENDPOINT1_CONFIG	ENDPOINT_TRANSIMIT_ONLY
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_ONLY
@@ -648,7 +648,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define FLIGHTSIM_RX_INTERVAL	1
   #define JOYSTICK_INTERFACE    7	// Joystick
   #define JOYSTICK_ENDPOINT     10
-  #define JOYSTICK_SIZE         16
+  #define JOYSTICK_SIZE         12	//  12 = normal, 64 = extreme joystick
   #define JOYSTICK_INTERVAL     1
 /*
   #define MTP_INTERFACE		8	// MTP Disk

--- a/src/platform/arm-teensy3/usb_dev.h
+++ b/src/platform/arm-teensy3/usb_dev.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/platform/arm-teensy3/usb_mem.h
+++ b/src/platform/arm-teensy3/usb_mem.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -44,7 +44,7 @@ typedef struct usb_packet_struct {
 extern "C" {
 #endif
 
-usb_packet_t * usb_malloc(void);
+usb_packet_t * usb_malloc(int);
 void usb_free(usb_packet_t *p);
 
 #ifdef __cplusplus

--- a/src/platform/arm-teensy3/usb_names.h
+++ b/src/platform/arm-teensy3/usb_names.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the

--- a/src/platform/arm-teensy3/usb_serial.c
+++ b/src/platform/arm-teensy3/usb_serial.c
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -206,7 +206,7 @@ int usb_serial_write(const void *buffer, uint32_t size)
 				}
 				if (usb_tx_packet_count(CDC_TX_ENDPOINT) < TX_PACKET_LIMIT) {
 					tx_noautoflush = 1;
-					tx_packet = usb_malloc();
+					tx_packet = usb_malloc(0);
 					if (tx_packet) break;
 					tx_noautoflush = 0;
 				}
@@ -243,7 +243,7 @@ int usb_serial_write_buffer_free(void)
 	if (!tx_packet) {
 		if (!usb_configuration ||
 		  usb_tx_packet_count(CDC_TX_ENDPOINT) >= TX_PACKET_LIMIT ||
-		  (tx_packet = usb_malloc()) == NULL) {
+		  (tx_packet = usb_malloc(0)) == NULL) {
 			tx_noautoflush = 0;
 			return 0;
 		}
@@ -270,7 +270,7 @@ void usb_serial_flush_output(void)
 		usb_tx(CDC_TX_ENDPOINT, tx_packet);
 		tx_packet = NULL;
 	} else {
-		usb_packet_t *tx = usb_malloc();
+		usb_packet_t *tx = usb_malloc(0);
 		if (tx) {
 			usb_cdc_transmit_flush_timer = 0;
 			usb_tx(CDC_TX_ENDPOINT, tx);
@@ -289,7 +289,7 @@ void usb_serial_flush_callback(void)
 		usb_tx(CDC_TX_ENDPOINT, tx_packet);
 		tx_packet = NULL;
 	} else {
-		usb_packet_t *tx = usb_malloc();
+		usb_packet_t *tx = usb_malloc(0);
 		if (tx) {
 			usb_tx(CDC_TX_ENDPOINT, tx);
 		} else {

--- a/src/platform/arm-teensy3/usb_serial.h
+++ b/src/platform/arm-teensy3/usb_serial.h
@@ -1,6 +1,6 @@
 /* Teensyduino Core Library
  * http://www.pjrc.com/teensy/
- * Copyright (c) 2013 PJRC.COM, LLC.
+ * Copyright (c) 2017 PJRC.COM, LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -71,7 +71,19 @@ extern volatile uint8_t usb_configuration;
 class usb_serial_class : public Stream
 {
 public:
-        void begin(long) { /* TODO: call a function that tries to wait for enumeration */ };
+	constexpr usb_serial_class() {}
+        void begin(long) {
+		uint32_t millis_begin = systick_millis_count;
+		while (!(*this)) {
+			// wait up to 2.5 seconds for Arduino Serial Monitor
+			// Yes, this is a long time, but some Windows systems open
+			// the port very slowly.  This wait allows programs for
+			// Arduino Uno to "just work" (without forcing a reboot when
+			// the port is opened), and when no PC is connected the user's
+			// sketch still gets to run normally after this wait time.
+			if ((uint32_t)(systick_millis_count - millis_begin) > 2500) break;
+		}
+	}
         void end() { /* TODO: flush output and shut down USB port */ };
         virtual int available() { return usb_serial_available(); }
         virtual int read() { return usb_serial_getchar(); }
@@ -84,7 +96,7 @@ public:
 	size_t write(long n) { return write((uint8_t)n); }
 	size_t write(unsigned int n) { return write((uint8_t)n); }
 	size_t write(int n) { return write((uint8_t)n); }
-	int availableForWrite() { return usb_serial_write_buffer_free(); }
+	virtual int availableForWrite() { return usb_serial_write_buffer_free(); }
 	using Print::write;
         void send_now(void) { usb_serial_flush_output(); }
         uint32_t baud(void) { return usb_cdc_line_coding[0]; }
@@ -122,12 +134,14 @@ extern void serialEvent(void);
 class usb_serial_class : public Stream
 {
 public:
+	constexpr usb_serial_class() {}
         void begin(long) { };
         void end() { };
         virtual int available() { return 0; }
         virtual int read() { return -1; }
         virtual int peek() { return -1; }
         virtual void flush() { }
+        virtual void clear() { }
         virtual size_t write(uint8_t c) { return 1; }
         virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
 	size_t write(unsigned long n) { return 1; }

--- a/src/platform/arm-teensy3/watchdog.fth
+++ b/src/platform/arm-teensy3/watchdog.fth
@@ -1,4 +1,0 @@
-\ reset the system
-\ a write to the watchdog unlock register that isn't the magic values
-\ will force a watchdog interrupt-then-reset.
-: wd  0 4005200e !  ;


### PR DESCRIPTION
- rebase arm-teensy3 platform code, to
  f0d263c540180ef173f639224e93e7c6ce9c5d3d from
  https://github.com/PaulStoffregen/cores

- allow any pin for analog writes,

- avoid redundant usb_init and analog_init calls,

- add RTC access words, thanks to Mitch's textend.c,

- fix layout of ccalls,

- fix paste via USB, by using half of the USB buffers for the TX path,
  and half for the RX path, and hand over only RX buffers when RX
  exhaustion is detected, tested with a million lines of paste,

- separate console controls; add new words uart-on uart-off uart? for
  controlling UART console, and usb-on usb-off usb? for controlling USB
  console,

- add new word restart to use watchdog method for forcing system reset,
  and allow bye to fall out of interpreter into restart,

- add new word reflash for placing system into wait for loader,
  equivalent to pressing the button,

- remove watchdog test file; only ever used for restarting.

- use $PATH for teensy_loader_cli,

- add -dirty to version if repository not pristine,

- clean up build log.

Co-authored-by: James Cameron <quozl@laptop.org>