### PR TITLE
arm-teensy3 - serial receive hardware flow control

### DIFF
--- a/src/platform/arm-teensy3/consoleio.c
+++ b/src/platform/arm-teensy3/consoleio.c
@@ -193,6 +193,12 @@ void init_uart()
   // sre - slew rate enable, slow, p229
   CORE_PIN1_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
 
+#ifdef ENABLE_RTS
+  // hardware flow control on receive path only, using RTS
+  CORE_PIN6_CONFIG = PORT_PCR_DSE | PORT_PCR_SRE | PORT_PCR_MUX(3);
+  UART0_MODEM = UART_MODEM_RXRTSE;
+#endif
+
   // baud rate generator, 115200, derived from test build
   // reference, *RM.pdf, table 47-57, page 1275, 38400 baud?
   UART0_BDH = 0;


### PR DESCRIPTION
When enabled in build, Teensy 3.1 pin 6 is RTS and must be tied to CTS of host.  Host must be configured to observe CTS.

Tested with `screen /dev/ttyUSB0 115200,crtscts` no issues.

Tested with `cat /dev/ttyUSB0` and

```
for x in $(seq 10000); do
     echo -e "get-msecs .d ( $x )\n" > /dev/ttyUSB0;
done
```
with no issues.

@jordanhubbard, for your interest, this fixes pasting over UART, at the expense of one more wire.