### PR TITLE
not for merging - arm-teensy-lc: add MKL26Z64 support

### DIFF
--- a/src/app/arm-teensy3/app.fth
+++ b/src/app/arm-teensy3/app.fth
@@ -1,13 +1,6 @@
 \ Load file for application-specific Forth extensions
 
-fl ../../lib/misc.fth
-fl ../../lib/dl.fth
-
-fl ../../platform/arm-teensy3/timer.fth
-fl ../../platform/arm-teensy3/pcr.fth
-fl ../../platform/arm-teensy3/i2c.fth
 fl ../../platform/arm-teensy3/gpio.fth
-fl ../../platform/arm-teensy3/nv.fth
 
 : be-in      0 swap m!  ;
 : be-out     1 swap m!  ;
@@ -33,34 +26,6 @@ fl ../../platform/arm-teensy3/nv.fth
    until
 ;
 
-\ tsl2561 luminosity sensor
-: .tsl
-   h# 39 i2c-open
-   3 80 i2c-reg! \ power up sensor
-   d# 402 ms \ nominal integration time
-   h# 8c i2c-reg@ h# 8d i2c-reg@ bwjoin . \ ADC channel 0
-   h# 8e i2c-reg@ h# 8f i2c-reg@ bwjoin . \ ADC channel 1
-   0 80 i2c-reg! \ power down sensor
-   i2c-close
-;
-
-\ blink the led
-: go
-   $1 $d m!  $1 $d p!   \ mode output, drive on
-   #10 ms		\ pause
-   $0 $d p!  $0 $d m!   \ drive off, mode input
-;
-
-\ to prevent execution of non-volatile buffer, tie pin 13 to pin 14.
-: confirm?  ( -- flag )
-   $0 $e m!                     \ set pin 14 to input
-   $1 $d m!  $1 $d p!  $2 ms    \ force pin 13 high
-   $e p@                        \ read pin
-   $0 $d p!  $2 ms              \ force low
-   $e p@ 0=                     \ read pin and invert
-   and 0=
-;
-
 : .commit  ( -- )  'version cscount type  ;
 
 : .built  ( -- )  'build-date cscount type  ;
@@ -72,7 +37,6 @@ fl ../../platform/arm-teensy3/nv.fth
 ;
 
 : app
-   confirm?  if  go  nv-evaluate  then
    banner
    hex quit
 ;

--- a/src/cforth/load.fth
+++ b/src/cforth/load.fth
@@ -44,6 +44,7 @@ fload locals.fth	\ LOCALS
 [ifdef] $command
 fload cmdcom.fth
 [then]
-fload debug.fth
+
+hex
 
 " forth.dic" save

--- a/src/platform/arm-teensy3/consoleio.c
+++ b/src/platform/arm-teensy3/consoleio.c
@@ -145,7 +145,7 @@ void putline(char *str)
 
 int kbhit()
 {
-  if (UART0_RCFIFO > 0) {
+  if (UART0_S1 & UART_S1_RDRF) {
     use_uart++;
     return 1;
   }
@@ -164,7 +164,7 @@ int getkey()
     sent_usb = 0;
   }
   while (1) {
-    if (UART0_RCFIFO > 0) {
+    if (UART0_S1 & UART_S1_RDRF) {
       c = UART0_D;
       use_uart++;
       return c;
@@ -199,13 +199,10 @@ void init_uart()
   UART0_BDL = 0x1a;
   UART0_C4 = 0x1;
 
-  // fifo enable
-  UART0_PFIFO = UART_PFIFO_TXFE | UART_PFIFO_RXFE;
-
   // transmitter enable, receiver enable
   UART0_C2 = UART_C2_TE | UART_C2_RE;
 
-  use_uart = 0;
+  use_uart = 1;
   use_usb = 0;
   sent_usb = 0;
 }

--- a/src/platform/arm-teensy3/mkl26z64.ld
+++ b/src/platform/arm-teensy3/mkl26z64.ld
@@ -1,0 +1,112 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+MEMORY
+{
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 62K
+	RAM  (rwx) : ORIGIN = 0x1FFFF800, LENGTH = 8K
+}
+
+
+SECTIONS
+{
+	.text : {
+		. = 0;
+		KEEP(*(.vectors))
+		*(.startup*)
+		/* TODO: does linker detect startup overflow onto flashconfig? */
+		. = 0x400;
+		KEEP(*(.flashconfig*))
+		*(.text*)
+		*(.rodata*)
+		. = ALIGN(4);
+		KEEP(*(.init))
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+	} > FLASH = 0xFF
+
+	.ARM.exidx : {
+		__exidx_start = .;
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+		__exidx_end = .;
+	} > FLASH
+	_etext = .;
+
+	.usbdescriptortable (NOLOAD) : {
+		/* . = ORIGIN(RAM); */
+		. = ALIGN(512);
+		*(.usbdescriptortable*)
+	} > RAM
+
+	.dmabuffers (NOLOAD) : {
+		. = ALIGN(4);
+		*(.dmabuffers*)
+	} > RAM
+
+	.usbbuffers (NOLOAD) : {
+		. = ALIGN(4);
+		*(.usbbuffers*)
+	} > RAM
+
+	.data : AT (_etext) {
+		. = ALIGN(4);
+		_sdata = .; 
+		*(.fastrun*)
+		*(.data*)
+		. = ALIGN(4);
+		_edata = .; 
+	} > RAM
+
+	.noinit (NOLOAD) : {
+		*(.noinit*)
+	} > RAM
+
+	.bss : {
+		. = ALIGN(4);
+		_sbss = .;
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		_ebss = .;
+		__bss_end = .;
+		__bss_end__ = .;
+	} > RAM
+
+	_estack = ORIGIN(RAM) + LENGTH(RAM);
+}
+
+

--- a/src/platform/arm-teensy3/pins_teensy.c
+++ b/src/platform/arm-teensy3/pins_teensy.c
@@ -578,7 +578,6 @@ void _init_Teensyduino_internal_(void)
 	TPM1_C1SC = 0x28;
 	TPM1_SC = FTM_SC_CLKS(1) | FTM_SC_PS(0);
 #endif
-	analog_init();
 	// for background about this startup delay, please see these conversations
 	// https://forum.pjrc.com/threads/36606-startup-time-(400ms)?p=113980&viewfull=1#post113980
 	// https://forum.pjrc.com/threads/31290-Teensey-3-2-Teensey-Loader-1-24-Issues?p=87273&viewfull=1#post87273

--- a/src/platform/arm-teensy3/targets.mk
+++ b/src/platform/arm-teensy3/targets.mk
@@ -4,16 +4,16 @@ SRC=$(TOPDIR)/src
 
 # Target compiler definitions
 CROSS ?= arm-none-eabi-
-CPU_VARIANT=-mthumb -mcpu=cortex-m4
+CPU_VARIANT=-mthumb -mcpu=cortex-m0
 include $(SRC)/cpu/arm/compiler.mk
 
 include $(SRC)/common.mk
 include $(SRC)/cforth/targets.mk
 
-DEFS += -DF_CPU=48000000 -DUSB_SERIAL -DLAYOUT_US_ENGLISH -D__MK20DX256__ -DARDUINO=105 -DTEENSYDUINO=118
+DEFS += -DF_CPU=48000000 -DUSB_SERIAL -DLAYOUT_US_ENGLISH -D__MKL26Z64__ -DARDUINO=105 -DTEENSYDUINO=118
 
 DICTIONARY=ROM
-DICTSIZE=0x2000
+DICTSIZE=0xb00
 
 include $(SRC)/cforth/embed/targets.mk
 
@@ -24,7 +24,7 @@ TCFLAGS += -Os
 # Omit unreachable functions from output
 
 TCFLAGS += -ffunction-sections -fdata-sections $(DEFS)
-TLFLAGS += --gc-sections -Map main.map
+TLFLAGS += --gc-sections -Map main.map --cref
 
 # VPATH += $(SRC)/cpu/arm
 VPATH += $(SRC)/lib
@@ -38,7 +38,7 @@ INCS += -I$(SRC)/platform/arm-teensy3
 
 tconsoleio.o: vars.h
 
-PLAT_OBJS += tmk20dx128.o ttmain.o tconsoleio.o tusb_dev.o tusb_mem.o tusb_desc.o tusb_serial.o tanalog.o tpins_teensy.o teeprom.o mallocembed.o
+PLAT_OBJS += tmk20dx128.o ttmain.o tconsoleio.o tusb_dev.o tusb_mem.o tusb_desc.o tusb_serial.o tpins_teensy.o mallocembed.o
 
 # Object files for the Forth system and application-specific extensions
 
@@ -47,7 +47,7 @@ FORTH_OBJS = tembed.o textend.o
 
 # Recipe for linking the final image
 
-LDSCRIPT = $(SRC)/platform/arm-teensy3/mk20dx256.ld
+LDSCRIPT = $(SRC)/platform/arm-teensy3/mkl26z64.ld
 
 app.elf: $(PLAT_OBJS) $(FORTH_OBJS) tdate.o
 	@echo Linking $@ ... 
@@ -65,7 +65,7 @@ app.elf: $(PLAT_OBJS) $(FORTH_OBJS) tdate.o
 
 # This rule loads the hex file to the module
 burn: app.hex
-	teensy_loader_cli -w -mmcu=mk20dx128 app.hex
+	teensy_loader_cli -w -mmcu=mkl26z64 app.hex
 
 # This rule builds a date stamp object that you can include in the image
 # if you wish.

--- a/src/platform/arm-teensy3/textend.c
+++ b/src/platform/arm-teensy3/textend.c
@@ -16,11 +16,6 @@ cell pinMode();
 cell micros();
 cell delay();
 cell _reboot_Teensyduino_();
-cell eeprom_size();
-cell eeprom_base();
-cell eeprom_length();
-cell eeprom_read_byte();
-cell eeprom_write_byte();
 unsigned long rtc_get(void);
 void rtc_set(unsigned long t);
 void rtc_compensate(int adjust);
@@ -67,18 +62,11 @@ cell ((* const ccalls[])()) = {
         C(spins)                //c spins               { i.nspins -- }
         C(wfi)                  //c wfi                 { -- }
         C(get_msecs)            //c get-msecs           { -- n }
-        C(analogWrite)          //c a!                  { i.val i.pin -- }
-        C(analogRead)           //c a@                  { i.pin -- n }
         C(digitalWrite)         //c p!                  { i.val i.pin -- }
         C(digitalRead)          //c p@                  { i.pin -- n }
         C(pinMode)              //c m!                  { i.mode i.pin -- }
         C(micros)               //c get-usecs           { -- n }
         C(delay)                //c ms                  { i.#ms -- }
-        C(eeprom_size)          //c /nv                 { -- n }
-        C(eeprom_base)          //c nv-base             { -- n }
-        C(eeprom_length)        //c nv-length           { -- n }
-        C(eeprom_read_byte)     //c nv@                 { i.adr -- i.val }
-        C(eeprom_write_byte)    //c nv!                 { i.val i.adr -- }
         C(build_date_adr)       //c 'build-date         { -- a.value }
         C(version_adr)          //c 'version            { -- a.value }
         C(rtc_get)              //c rtc@                { -- i.val }


### PR DESCRIPTION
For interest only, not for merging, a bringup on Teensy LC.

* add linker script, change MCU, use Cortex-M0 instructions,

* remove UART FIFO, the MCU doesn't have it,

* cramming; remove eeprom, analog and debug support, reduce RAM
  dictionary size, add cross reference to map,

* restore `base` after removal of debug support; `debug.fth` sets `base` to hex as a side-effect, and when the `fload` is removed `base` is no longer hex during `app.fth`

* tested on Teensy LC, a terribly close fit at 99%.

```
arm-none-eabi-size app.elf
   text    data     bss     dec     hex filename
  63116     168    7864   71148   115ec app.elf
```