### PR TITLE
arm-xo-1.75: check that we don't use Thumb instructions

### DIFF
--- a/src/platform/arm-xo-1.75/targets.mk
+++ b/src/platform/arm-xo-1.75/targets.mk
@@ -74,6 +74,7 @@ cforth.elf: version $(PLAT_OBJS) $(FORTH_OBJS)
 	    $(PLAT_OBJS) $(FORTH_OBJS) date.o \
 	    $(LIBDIRS) $(LIBGCC)
 	@$(TOBJDUMP) $(DUMPFLAGS) $@ >$(@:.elf=.dump)
+	@if egrep -q '^\S{8}:\s\S{4}\s' $(@:.elf=.dump); then echo 'PJ1 has no Thumb support. Wrong libgcc?'; rm $@; exit 1; fi
 	@nm -n $@ >$(@:.elf=.nm)
 
 shim.elf: $(PLAT_OBJS) $(SHIM_OBJS)


### PR DESCRIPTION
However, some distributions, such as Debian/armhf, ship with libgcc that uses
Thumb-2 instructions in their toolchains. The PJ1/Mohawk "security processor"
core has no support for that.

Let's add a sanity check, because CForth not working is a big deal (the
machine can't be unbricked without disassembling it).

Sadly, there doesn't seem to be a way to tell the linker to avoid
thumb-compiled binaries. Grepping for 16-bit instrucitons in our
disasembly does the trick for now.