### PR TITLE
arm-xo-1.75: default to using the cross-compiler

### DIFF
--- a/src/platform/arm-xo-1.75/targets.mk
+++ b/src/platform/arm-xo-1.75/targets.mk
@@ -2,15 +2,10 @@
 
 SRC=$(TOPDIR)/src
 
-CPU_VARIANT=-marm -mcpu=strongarm110
-
 # Target compiler definitions
-ifneq "$(findstring arm,$(shell uname -m))" ""
-TCFLAGS += $(CPU_VARIANT)
-include $(SRC)/cpu/host/compiler.mk
-else
+CROSS ?= arm-none-eabi-
+CPU_VARIANT=-marm -mcpu=strongarm110
 include $(SRC)/cpu/arm/compiler.mk
-endif
 
 VPATH += $(SRC)/cpu/arm $(SRC)/lib
 VPATH += $(SRC)/platform/arm-xo-1.75


### PR DESCRIPTION
The native toolchain of Debian/armhf, and perhaps some other operating
systems, ships with libgcc that's no good for running on the "security
processor" PJ1/Mohawk core, because it uses Thumb-2 instructions.

Let's switch to the arm-none-eabi toolchain. It is available on both
Debian and Fedora regardless of what the native architecture is, so
it might be a pretty good default.