### PR TITLE
Add support for Dell Wyse 3020

### DIFF
--- a/build/arm-ariel/Makefile
+++ b/build/arm-ariel/Makefile
@@ -1,0 +1,11 @@
+# Builds CForth for Ariel (Dell Wyse 3020)
+
+TOPDIR=../..
+
+CONFIG += -DBITS32 -DT16
+
+ifneq "$(shell getconf LONG_BIT)" "32"
+CFLAGS += -m32
+endif
+
+include $(TOPDIR)/src/app/arm-ariel/targets.mk

--- a/build/arm-xo-cl4/Makefile
+++ b/build/arm-xo-cl4/Makefile
@@ -1,5 +1,11 @@
-# Builds CForth for OLPC XO-1.75
+# Builds CForth for OLPC XO-4
 
 TOPDIR=../..
+
+CONFIG += -DBITS32 -DT16
+
+ifneq "$(shell getconf LONG_BIT)" "32"
+CFLAGS += -m32
+endif
 
 include $(TOPDIR)/src/app/arm-xo-cl4/targets.mk

--- a/src/app/arm-ariel/app.fth
+++ b/src/app/arm-ariel/app.fth
@@ -1,0 +1,92 @@
+\ Ariel (Dell Wyse 3020) board support
+\
+\ Copyright (C) 2020 Lubomir Rintel <lkundrak@v3.sk>
+\
+\ Based on src/app/arm-xo-cl4/app.fth and
+\ src/app/arm-xo-1.75/olpcbasics.fth
+
+create mmp3
+
+h#   10.0000 constant /rom
+h# 08fe.0000 constant dlofw-base
+
+fl ../arm-ariel/gpiopins.fth
+fl ../arm-mmp2/mfprbits.fth
+fl ../arm-ariel/mfprtable.fth
+fl ../arm-mmp2/mmp2drivers.fth
+fl ../arm-ariel/boardgpio.fth
+fl ../arm-xo-cl4/clockset.fth
+fl ../arm-ariel/initdram.fth
+fl ../arm-xo-1.75/smbus.fth
+fl ../arm-xo-1.75/addrs.fth
+fl ../arm-mmp2/lcd.fth
+fl ../arm-ariel/panel.fth
+fl ../arm-xo-1.75/banner.fth
+fl ../arm-xo-1.75/controls.fth
+fl ../arm-xo-1.75/showfb.fth
+fl ../arm-xo-1.75/hackspi.fth
+fl ../arm-xo-1.75/dropin.fth
+fl ../arm-xo-1.75/showlog.fth
+fl ../arm-xo-1.75/showpmu.fth  \ Power management debugging words
+fl ../arm-xo-1.75/showicu.fth  \ Interrupt controller debugging words
+fl ../arm-xo-1.75/memtest.fth
+
+: ariel-ec-pulse  ( -- )
+   \ We're supposed to signal readiness to power off to the EC with a
+   \ 10 MHz pulse. Delays of 48ms - 68ms seem to create a wave that's
+   \ good enough for the EC. Choose the middle value
+   begin
+      ec-off-pulse-gpio# gpio-clr  d# 58 ms
+      ec-off-pulse-gpio# gpio-set  d# 58 ms
+   again
+;
+
+: power-off  ( -- )
+   ec-off-type-gpio# gpio-set
+   ariel-ec-pulse
+;
+
+: reboot  ( -- )
+   ec-off-type-gpio# gpio-clr
+   ariel-ec-pulse
+;
+
+: ?startup-problem  ( -- )
+   thermal?  if  ." thermal power-off" cr  power-off  then
+   watchdog?  if  ." watchdog restart" cr  epitaph  bye  then
+   setup-thermal
+;
+
+: late-init
+   ?startup-problem
+   set-frequency-1.2g
+   init-dram
+;
+
+: release-main-cpu  ( -- )
+   h# 02 h# 050020 +io bitclr   \ Release reset for PJ4 (MPCORE 1)
+;
+
+fl ../arm-xo-1.75/ofw.fth
+
+\ Run this at startup
+: app  ( -- )
+   h# 20 mpmu@ 2 and  0=  if
+      ." CForth unexpected restart! - freezing PJ4" cr
+      2  h# 20 mpmu-set
+      quit
+   then
+   banner
+   basic-setup
+   init-timers
+   enable-wdt-clock
+   set-gpio-directions
+   init-mfprs
+   early-activate-cforth?  0=  if
+      ['] ofw catch .error
+   then
+   ." Skipping OFW" cr
+   hex quit
+;
+
+" app.dic" save

--- a/src/app/arm-ariel/boardgpio.fth
+++ b/src/app/arm-ariel/boardgpio.fth
@@ -1,0 +1,12 @@
+purpose: Board-specific setup details - pin assigments, etc.
+
+: gpio-out-clr  ( gpio# -- )  dup gpio-clr  gpio-dir-out  ;
+: gpio-out-set  ( gpio# -- )  dup gpio-set  gpio-dir-out  ;
+
+: set-gpio-directions  ( -- )
+   3  h# 38 clock-unit-pa +  io!  \ Enable clocks in GPIO clock reset register
+
+   spi-flash-cs-gpio#   gpio-dir-out
+   ec-off-pulse-gpio#   gpio-dir-out
+   ec-off-type-gpio#    gpio-dir-out
+;

--- a/src/app/arm-ariel/gpiopins.fth
+++ b/src/app/arm-ariel/gpiopins.fth
@@ -1,0 +1,8 @@
+\ Ariel (Dell Wyse 3020) GPIO pin assignments
+
+d#  46 constant spi-flash-cs-gpio#
+d#  56 constant ec-input-gpio#
+d#  62 constant dvi1-hpd-gpio#
+d#  63 constant hsic-reset-gpio#
+d# 126 constant ec-off-pulse-gpio#
+d# 127 constant ec-off-type-gpio#

--- a/src/app/arm-ariel/initdram.fth
+++ b/src/app/arm-ariel/initdram.fth
@@ -1,0 +1,139 @@
+\ Ariel (Dell Wyse 3020) DRAM initialization
+\
+\ Based on src/app/arm-mmp3-thunderstone/initdram.fth
+
+: set-frequency  ( -- )   \  Static Frequency Change
+   \ pjdiv 0, atdiv 2, reserved 3, peripheral 1, ddrdiv 0, axidiv 0, mb1 f, mb1 1
+   h# 00BC02D0  h# 004 pmua!	  	\ PMUA_CC_PJ  (octal 57001320)
+   h# 01fffe07  h# 150 pmua-clr		\ PMUA_CC2_PJ  - clear divisor fields
+
+   \  axi clk2 div = 1 (ratio = 2), mmcore pclk 1 (ratio = 2), aclk div 1 (ratio = 2)
+   h# 00220001  h# 150 pmua-set
+   h# 01f00000  h# 188 pmua-clr	\ PMUA_CC3_PJ  clear divisor field
+   h#   100000  h# 188 pmua-set	\  set low bit of ATCLK/PCLKDBG ratio field
+
+   \  PMUM_FCCR - PJCLKSEL 1 (use PLL1), SPCLKSEL 0 (PLL1/2),
+   \ DDRCLKSEL 0 (PLL1/2),  PLL1REFD = 0, PLL1FBD = 8
+   h# 20800000  h# 08 mpmu!
+
+   \ PMUA_BUS_CLK_RES_CTRL - DCLK2_PLL_SEL = 1 (PLL1),
+   \ SOC_AXI_CLK_PLL_SEL = 0 (PLL1/2), unreset both DDR channels
+   h# 00000203  h# 6c pmua!
+
+   \ h# 000FFFFF h# 088 pmua!
+   \ h# 000FFFFF h# 190 pmua!
+   d#   500 us
+   h# F0000000  h# 04 pmua-set	\  force frequency change
+   d#   500 us
+;
+
+: setup-platform  ( -- )
+   h# 0000E000 h# 1024 mpmu-set \ PMUM_CGR_PJ - enable APMU_PLL1, APMU_PLL2, APMU_PLL1_2
+   \  h# 88b99001 h# 00 pmua!    \ PMUA_CC_SP - frequency change for SP
+
+   \ PM programming upon SOD
+   \ PMUA_GENERIC_CTRL - bits 22,20,18,16,6,5,4  - tristate some pads in APIDLE state, enable SRAM retention
+   h# 00550070  h# 244 pmua-set
+
+   \  h# 00000000   h# 8c pmua!   \  Turn off coresight ram
+
+   h# 00005400 h# 0000fc00 h# 282c7c +io bitfld  \ CIU_PJ4MP1_PDWN_CFG_CTL - SRAM access delay
+   h# 00005400 h# 0000fc00 h# 282c80 +io bitfld  \ CIU_PJ4MP2_PDWN_CFG_CTL - SRAM access delay
+   h# 00005400 h# 0000fc00 h# 282c84 +io bitfld  \ CIU_PJ4MM_PDWN_CFG_CTL - SRAM access delay
+
+   h# f0000200 h# 248 pmua-clr	\ PMUA_PJ_C0_CC4 - clear L1_LOW_LEAK_DIS - UNDOCUMENTED!
+   h# f0000200 h# 24C pmua-clr	\ PMUA_PJ_C1_CC4 - clear L1_LOW_LEAK_DIS - UNDOCUMENTED!
+   h# f0000200 h# 250 pmua-clr	\ PMUA_PJ_C2_CC4 - clear L1_LOW_LEAK_DIS - UNDOCUMENTED!
+
+   set-frequency
+;
+
+hex
+create dram-tablex lalign
+   000E0001 , 010 ,		\ MMAP0
+   00046530 , 020 ,		\ SDRAM_CONFIG_TYPE1-CS0
+   00000000 , 030 ,		\ SDRAM_CONFIG_TYPE2-CS0
+
+   \ Timing
+   51250066 , 080 ,       	\ SDRAM_TIMING1
+   85880DF5 , 084 ,		\ SDRAM_TIMING2
+   248C2AC2 , 088 ,       	\ SDRAM_TIMING3
+   236350D1 , 08C ,       	\ SDRAM_TIMING4
+   001721B0 , 090 ,       	\ SDRAM_TIMING5
+   44040200 , 094 ,       	\ SDRAM_TIMING6
+   00005555 , 098 ,       	\ SDRAM_TIMING7
+
+   \ Control
+   00000000 , 050 ,		\ SDRAM_CTRL1
+   00000000 , 054 ,        	\ SDRAM_CTRL2
+   20C08009 , 058 ,       	\ SDRAM_CTRL4
+   00000201 , 05C ,		\ SDRAM_CTRL6_SDRAM_ODT_CTRL
+   0200000A , 060 ,		\ SDRAM_CTRL7_SDRAM_ODT_CTRL2
+   00000000 , 064 ,		\ SDRAM_CTRL13
+   00000000 , 068 ,		\ SDRAM_CTRL14
+
+   \ PHY Deskew PLL config and PHY initialization
+   00300008 , 240 ,		\ PHY_CTRL11
+   00005A01 , 24C ,		\ PHY_CTRL14
+   000031d8 , 23C ,		\ PHY_CTRL0
+   00004055 , 220 ,		\ PHY_CTRL3
+   1FF84A79 , 230 ,        	\ PHY_CTRL7
+   0FF00A70 , 234 ,        	\ PHY_CTRL8
+   000000A7 , 238 ,        	\ PHY_CTRL9
+   F0210000 , 248 ,      	\ PHY_CTRL13
+
+   \ PHY DLL Tuning
+   00000000 , 300 ,   00001080 , 304 ,
+   00000001 , 300 ,   00001080 , 304 ,
+   00000002 , 300 ,   00001080 , 304 ,
+   00000003 , 300 ,   00001080 , 304 ,
+
+   \ Read Leveling CS0
+   00000100 , 380 ,   00000200 , 390 ,
+   00000101 , 380 ,   00000200 , 390 ,
+   00000102 , 380 ,   00000200 , 390 ,
+   00000103 , 380 ,   00000200 , 390 ,
+
+here dram-tablex laligned - constant /dram-table
+
+
+: dram-table  dram-tablex laligned  ;
+: .table  ( -- )
+   dram-table /dram-table bounds  ?do
+      i . ." : "  i @ 8 u.r  space  i na1+ @ 8 u.r  cr
+   8 +loop
+;
+
+false value dram-on?
+: +mc  ( offset channel -- adr )
+   if  h# d000.0000  else  h# d001.0000  then  +
+;
+: mc!  ( value offset channel -- )  +mc l!  ;
+: mc@  ( offset channel -- value )  +mc l@  ;
+
+: reset-dll  ( mc# -- )
+   >r
+   h# 20000000 24c r@ mc!	\ DLL reset
+   d# 68 us
+   h# 00030001 160 r@ mc!	\ USER_INITIATED_COMMAND0 - reserved, SDRAM INIT
+   d# 68 us
+   h# 40000000 24c r> mc!	\ DLL update via pulse mode
+   h# 68 us
+;
+
+: init-dram
+   dram-on?  if  exit  then
+   true to dram-on?
+
+   setup-platform
+
+   2 0  do
+      dram-table /dram-table bounds  ?do
+         i @  i na1+ @  j  mc!
+      8 +loop
+      i reset-dll
+      begin  h# 8 i mc@ 1 and  until  \ Wait init done
+   loop
+
+   h# 20  h# 282ca0 io!   \ Interleave on 512 MB boundary
+;

--- a/src/app/arm-ariel/mfprtable.fth
+++ b/src/app/arm-ariel/mfprtable.fth
@@ -1,0 +1,178 @@
+\ Ariel (Dell Wyse 3020) Pin Mux configuration
+\
+\ Copyright (C) 2020 Lubomir Rintel <lkundrak@v3.sk>
+
+create mfpr-table
+     no-update,                 \ PIN0
+     no-update,                 \ PIN1
+     no-update,                 \ PIN2
+     no-update,                 \ PIN3
+     no-update,                 \ PIN4
+     no-update,                 \ PIN5
+     no-update,                 \ PIN6
+     no-update,                 \ PIN7
+     no-update,                 \ PIN8
+     no-update,                 \ PIN9
+     no-update,                 \ PIN10
+     no-update,                 \ PIN11
+     no-update,                 \ PIN12
+     no-update,                 \ PIN13
+     no-update,                 \ PIN14
+     no-update,                 \ PIN15
+     no-update,                 \ PIN16
+     no-update,                 \ PIN17
+     no-update,                 \ PIN18
+     no-update,                 \ PIN19
+     no-update,                 \ PIN20
+     no-update,                 \ PIN21
+     no-update,                 \ PIN22
+     no-update,                 \ PIN23
+     no-update,                 \ PIN24
+     no-update,                 \ PIN25
+     no-update,                 \ PIN26
+     no-update,                 \ PIN27
+     no-update,                 \ PIN28
+     no-update,                 \ PIN29
+     no-update,                 \ PIN30
+     no-update,                 \ PIN31
+     no-update,                 \ PIN32
+     no-update,                 \ PIN33
+     no-update,                 \ PIN34
+     no-update,                 \ PIN35
+     no-update,                 \ PIN36
+     no-update,                 \ PIN37
+     no-update,                 \ PIN38
+     no-update,                 \ PIN39
+     no-update,                 \ PIN40
+   2 +slow w,                   \ PIN41 - TWSI5
+   2 +slow w,                   \ PIN42 - TWSI5
+   3 +pull-up +medium w,        \ PIN43 - SSP1
+   3 +medium w,                 \ PIN44 - SSP1
+   3 +medium w,                 \ PIN45 - SSP1
+   0 +medium w,                 \ PIN46 - GPIO46
+   3 +slow w,                   \ PIN47 - TWSI6
+   3 +slow w,                   \ PIN48 - TWSI6
+     no-update,                 \ PIN49
+     no-update,                 \ PIN50
+     no-update,                 \ PIN51
+     no-update,                 \ PIN52
+     no-update,                 \ PIN53
+     no-update,                 \ PIN54
+   0 +pull-up-alt +pull-dn-alt +twsi w, \ PIN55 - GPIO55
+   0 +pull-up-alt +pull-dn-alt w,       \ PIN56 - GPIO56
+   0 +pull-up-alt +pull-dn-alt +twsi w, \ PIN57 - GPIO57
+   0 +pull-up-alt +pull-dn-alt w,       \ PIN58 - GPIO58
+     no-update,                 \ PIN59
+     no-update,                 \ PIN60
+     no-update,                 \ PIN61
+     no-update,                 \ PIN62
+     no-update,                 \ PIN63
+     no-update,                 \ PIN64
+     no-update,                 \ PIN65
+     no-update,                 \ PIN66
+     no-update,                 \ PIN67
+     no-update,                 \ PIN68
+     no-update,                 \ PIN69
+     no-update,                 \ PIN70
+   1 +slow w,                   \ PIN71 - TWSI3
+   1 +slow w,                   \ PIN72 - TWSI3
+     no-update,                 \ PIN73
+   1 +slow w,                   \ PIN74  - LCD
+   1 +slow w,                   \ PIN75  - LCD
+   1 +pull-up +medium +slow w,  \ PIN76  - LCD
+   1 +slow w,                   \ PIN77  - LCD
+   1 +slow w,                   \ PIN78  - LCD
+   1 +slow w,                   \ PIN79  - LCD
+   1 +slow w,                   \ PIN80  - LCD
+   1 +slow w,                   \ PIN81  - LCD
+   1 +slow w,                   \ PIN82  - LCD
+   1 +slow w,                   \ PIN83  - LCD
+   1 +slow w,                   \ PIN84  - LCD
+   1 +slow w,                   \ PIN85  - LCD
+   1 +slow w,                   \ PIN86  - LCD
+   1 +slow w,                   \ PIN87  - LCD
+   1 +slow w,                   \ PIN88  - LCD
+   1 +slow w,                   \ PIN89  - LCD
+   1 +slow w,                   \ PIN90  - LCD
+   1 +slow w,                   \ PIN91  - LCD
+   1 +slow w,                   \ PIN92  - LCD
+   1 +slow w,                   \ PIN93  - LCD
+   1 +slow w,                   \ PIN94  - LCD
+   1 +slow w,                   \ PIN95  - LCD
+   1 +slow w,                   \ PIN96  - LCD
+   1 +slow w,                   \ PIN97  - LCD
+   1 +slow w,                   \ PIN98  - LCD
+   1 +slow w,                   \ PIN99  - LCD
+   1 +slow w,                   \ PIN100 - LCD
+   1 +slow w,                   \ PIN101 - LCD
+     no-update,                 \ PIN102
+     no-update,                 \ PIN103
+   0 w,                         \ PIN104 - NAND
+   0 w,                         \ PIN105 - NAND
+   0 w,                         \ PIN106 - NAND
+   0 w,                         \ PIN107 - NAND
+   2 +medium w,                 \ PIN108 - NONE
+   2 +medium w,                 \ PIN109 - NONE
+   2 +medium w,                 \ PIN110 - NONE
+   2 +medium w,                 \ PIN111 - MMC3
+   0 w,                         \ PIN112 - NAND
+     no-update,                 \ PIN113
+     no-update,                 \ PIN114
+     no-update,                 \ PIN115
+     no-update,                 \ PIN116
+     no-update,                 \ PIN117
+     no-update,                 \ PIN118
+     no-update,                 \ PIN119
+     no-update,                 \ PIN120
+     no-update,                 \ PIN121
+     no-update,                 \ PIN122
+     no-update,                 \ PIN123
+     no-update,                 \ PIN124
+     no-update,                 \ PIN125
+   0 +pull-up-alt w,            \ PIN126 - GPIO126
+   0 +pull-up-alt w,            \ PIN127 - GPIO127
+     no-update,                 \ PIN128
+     no-update,                 \ PIN129
+     no-update,                 \ PIN130
+   1 +medium w,                 \ PIN131 - MMC1
+   1 +medium w,                 \ PIN132 - MMC1
+   1 +medium w,                 \ PIN133 - MMC1
+   1 +medium w,                 \ PIN134 - MMC1
+   1 +medium w,                 \ PIN135 - NONE
+   1 +medium w,                 \ PIN136 - MMC1
+     no-update,                 \ PIN137
+     no-update,                 \ PIN138
+     no-update,                 \ PIN139
+   1 +pull-up w,                \ PIN140 - MMC1
+   1 +pull-up w,                \ PIN141 - MMC1
+     no-update,                 \ PIN142
+   0 w,                         \ PIN143 - NAND
+   0 w,                         \ PIN144 - NAND
+   2 +medium w,                 \ PIN145 - NONE
+   2 +medium w,                 \ PIN146 - NONE
+   0 w,                         \ PIN147 - NAND
+   0 w,                         \ PIN148 - NAND
+   0 w,                         \ PIN149 - NAND
+   0 w,                         \ PIN150 - NAND
+   0 w,                         \ PIN151 - SMC
+   0 w,                         \ PIN152 - SMC
+     no-update,                 \ PIN153
+   0 w,                         \ PIN154 - SMC_INT
+     no-update,                 \ PIN155
+     no-update,                 \ PIN156
+     no-update,                 \ PIN157
+     no-update,                 \ PIN158
+     no-update,                 \ PIN159
+     no-update,                 \ PIN160
+   2 +medium w,                 \ PIN161 - NONE
+   2 +medium w,                 \ PIN162 - MMC3
+   2 +medium w,                 \ PIN163 - MMC3
+   2 +medium w,                 \ PIN164 - MMC3
+   0 w,                         \ PIN165 - NAND
+   0 w,                         \ PIN166 - NAND
+   0 w,                         \ PIN167 - NAND
+   0 w,                         \ PIN168 - NAND
+   0 +slow w,                   \ PIN169 - TWSI4_SCL
+   0 +slow w,                   \ PIN170 - TWSI4_SDA
+     no-update,                 \ PIN171
+here mfpr-table - /w / constant #mfprs

--- a/src/app/arm-ariel/panel.fth
+++ b/src/app/arm-ariel/panel.fth
@@ -1,0 +1,151 @@
+\ Ariel (Dell Wyse 3020) Video Encoder configuration
+\
+\ Copyright (C) 2020 Lubomir Rintel <lkundrak@v3.sk>
+\
+\ TWSI I2C access routines based on
+\ src/app/arm-mmp3-thunderstone/initdram.fth
+
+d# 1024 to hdisp  \ Display width
+d# 1344 to htotal \ Display + FP + Sync + BP
+
+d#  768 to vdisp  \ Display width
+d#  806 to vtotal \ Display + FP + Sync + BP
+
+: twsi3!  ( n offset -- )  h# 32000 + io!  ;
+: twsi3-clk-on  ( -- )
+   h# 000000004 h# 1500C io!
+   d# 500 us
+   h# 000000007 h# 1500C io!
+   d# 500 us
+   h# 000000003 h# 1500C io!
+   d# 500 us
+;
+: init-twsi3  ( -- )
+   h# 4060 h# 10 twsi3!  d# 500 us
+   h#   60 h# 10 twsi3!  d# 500 us
+   h#    0 h# 10 twsi3!
+;
+: setup-twsi3  ( -- )
+   \ TWSI3 pins
+   h# 00000801 h# 01E2B0 +io bitset	\  Set MFPR to AF1 for TWSI3_SCL
+   h# 00000801 h# 01E2B4 +io bitset	\  Set MFPR to AF1 for TWSI3_SDA
+   d# 500 us
+
+   twsi3-clk-on
+   init-twsi3
+;
+: twsi3-put  ( n reg10-val -- )  swap 8 twsi3!  h# 10 twsi3!  d# 500 us  ;
+: twsi3-reg!  ( value reg# slave-adr -- )
+   h# 69 twsi3-put  h# 68 twsi3-put  h# 6a twsi3-put  d# 20000 us
+;
+
+: init-panel  ( -- )
+   \ Reset
+   h# 04 h# 03 h# 76 twsi3-reg!
+   h# 00 h# 52 h# 76 twsi3-reg! \ Turn everything off to set all the registers to their defaults
+   h# 02 h# 52 h# 76 twsi3-reg! \ Bring I/O block up
+
+   \ Page 0
+   h# 00 h# 03 h# 76 twsi3-reg!
+
+   \ Bring up parts we need from the power down
+   h# d7 h# 07 h# 76 twsi3-reg!
+   h# 00 h# 08 h# 76 twsi3-reg!
+   h# 1a h# 09 h# 76 twsi3-reg!
+   h# 9a h# 0a h# 76 twsi3-reg!
+
+   \ Horizontal input timing
+   h# 2c h# 0b h# 76 twsi3-reg!
+   h# 00 h# 0c h# 76 twsi3-reg!
+   h# 40 h# 0d h# 76 twsi3-reg!
+   h# 00 h# 0e h# 76 twsi3-reg!
+   h# 18 h# 0f h# 76 twsi3-reg!
+   h# 88 h# 10 h# 76 twsi3-reg!
+
+   \ Vertical input timing
+   h# 1b h# 11 h# 76 twsi3-reg!
+   h# 00 h# 12 h# 76 twsi3-reg!
+   h# 26 h# 13 h# 76 twsi3-reg!
+   h# 00 h# 14 h# 76 twsi3-reg!
+   h# 03 h# 15 h# 76 twsi3-reg!
+   h# 06 h# 16 h# 76 twsi3-reg!
+
+   \ Input color swap
+   \ h# 00 h# 18 h# 76 twsi3-reg!
+   h# 05 h# 18 h# 76 twsi3-reg!
+
+   \ Input clock and sync polarity
+   h# f8 h# 19 h# 76 twsi3-reg!
+   h# c8 h# 19 h# 76 twsi3-reg!
+   h# fd h# 1a h# 76 twsi3-reg!
+   h# e8 h# 1b h# 76 twsi3-reg!
+
+   \ Horizontal output timing
+   h# 2c h# 1f h# 76 twsi3-reg!
+   h# 00 h# 20 h# 76 twsi3-reg!
+   h# 40 h# 21 h# 76 twsi3-reg!
+
+   \ Vertical output timing
+   h# 1b h# 25 h# 76 twsi3-reg!
+   h# 00 h# 26 h# 76 twsi3-reg!
+   h# 26 h# 27 h# 76 twsi3-reg!
+
+   \ VGA channel bypass
+   h# 09 h# 2b h# 76 twsi3-reg!
+
+   \ Output sync polarity
+   h# 27 h# 2e h# 76 twsi3-reg!
+
+   \ HDMI horizontal output timing
+   h# 80 h# 54 h# 76 twsi3-reg!
+   h# 18 h# 55 h# 76 twsi3-reg!
+   h# 88 h# 56 h# 76 twsi3-reg!
+
+   \ HDMI vertical output timing
+   h# 00 h# 57 h# 76 twsi3-reg!
+   h# 03 h# 58 h# 76 twsi3-reg!
+   h# 06 h# 59 h# 76 twsi3-reg!
+
+   \ Pick HDMI, not LVDS
+   h# 8f h# 7e h# 76 twsi3-reg!
+
+   \ Page 1
+   h# 01 h# 03 h# 76 twsi3-reg!
+
+   \ No idea what these do, but VGA is wobbly
+   \ and blinky without them
+   h# 66 h# 07 h# 76 twsi3-reg!
+   h# 05 h# 08 h# 76 twsi3-reg!
+
+   \ DRI PLL
+   h# 6a h# 0c h# 76 twsi3-reg!
+   h# 6a h# 0c h# 76 twsi3-reg!
+   h# 12 h# 6b h# 76 twsi3-reg!
+   h# 00 h# 6c h# 76 twsi3-reg!
+
+   \ This seems to be color calibration for VGA
+   h# 29 h# 64 h# 76 twsi3-reg! \ LSB Blue
+   h# 29 h# 65 h# 76 twsi3-reg! \ LSB Green
+   h# 29 h# 66 h# 76 twsi3-reg! \ LSB Red
+   h# 00 h# 67 h# 76 twsi3-reg! \ MSB Blue
+   h# 00 h# 68 h# 76 twsi3-reg! \ MSB Green
+   h# 00 h# 69 h# 76 twsi3-reg! \ MSB Red
+
+   \ Page 3
+   h# 03 h# 03 h# 76 twsi3-reg!
+
+   \ More bypasses and apparently another HDMI/LVDS selector
+   h# 0c h# 28 h# 76 twsi3-reg!
+   h# 28 h# 2a h# 76 twsi3-reg!
+
+   \ Page 4
+   h# 04 h# 03 h# 76 twsi3-reg!
+
+   \ Output clock
+   h# 00 h# 10 h# 76 twsi3-reg!
+   h# fd h# 11 h# 76 twsi3-reg!
+   h# e8 h# 12 h# 76 twsi3-reg!
+
+   \ Bring the display block up from reset
+   h# 03 h# 52 h# 76 twsi3-reg!
+;

--- a/src/app/arm-ariel/targets.mk
+++ b/src/app/arm-ariel/targets.mk
@@ -1,0 +1,15 @@
+# APPPATH is the path to the application code, i.e. this directory
+APPPATH=$(TOPDIR)/src/app/arm-ariel
+
+# APPLOADFILE is the top-level "Forth load file" for the application code.
+APPLOADFILE = app.fth
+
+# APPSRCS is a list of Forth source files that your application uses,
+# i.e. the list of files that app.fth floads.  It's for dependency checking.
+APPSRCS = $(wildcard $(APPPATH)/*.fth)
+
+DEFS += -DARIEL
+
+default: cforth.img
+
+include $(TOPDIR)/src/platform/arm-ariel/targets.mk

--- a/src/app/arm-mmp2/lcd.fth
+++ b/src/app/arm-mmp2/lcd.fth
@@ -91,6 +91,8 @@ d# 16 constant bpp
    0 h# 138 lcd!   \ Color key V
 ;
 
+: third  ( a b c -- a b c a )  2 pick  ;
+
 : centered  ( w h -- )
    hdisp third - 2/               ( w h x )    \ X centering offset
    vdisp third - 2/               ( w h x y )  \ Y centering offset

--- a/src/app/arm-mmp2/lcd.fth
+++ b/src/app/arm-mmp2/lcd.fth
@@ -1,4 +1,4 @@
-[ifdef] cl4
+[ifdef] mmp3
 \ This value has the same effect as the value below.  The
 \ difference is that the SCLK_SOURCE_SELECT field added a
 \ low-order bit (bit 29), so the high nibble changed from

--- a/src/app/arm-mmp3-thunderstone/basics.fth
+++ b/src/app/arm-mmp3-thunderstone/basics.fth
@@ -10,7 +10,6 @@ fl initdram.fth
 fl ../arm-xo-1.75/addrs.fth
 
 : wljoin  ( w w -- l )  d# 16 lshift or  ;
-: third  ( a b c -- a b c a )  2 pick  ;
 
 \ [ifdef] INCLUDE-DISPLAY
 fl ../arm-mmp2/lcd.fth

--- a/src/app/arm-xo-1.75/boardgpio.fth
+++ b/src/app/arm-xo-1.75/boardgpio.fth
@@ -24,7 +24,7 @@ purpose: Board-specific setup details - pin assigments, etc.
    led-storage-gpio#    gpio-dir-out
 [then]
 
-[ifdef] cl4
+[ifdef] mmp3
    vid2-gpio#           gpio-out-set
 [else]
    vid2-gpio#           gpio-out-clr

--- a/src/app/arm-xo-1.75/hackspi.fth
+++ b/src/app/arm-xo-1.75/hackspi.fth
@@ -180,9 +180,11 @@ h# 1010.0000 constant spi-mem-base
    false
 ;
 
+[ifdef] sec-trg-gpio#
 : sec-trg  ( -- )  sec-trg-gpio# gpio-set  ;
 
 : protect-fw  ( -- )  secure?  if  spi-protect sec-trg  then  ;
+[endif]
 
 \ Assumes offset is block-aligned
 : write-setup-dance  ( -- )

--- a/src/app/arm-xo-1.75/olpcbasics.fth
+++ b/src/app/arm-xo-1.75/olpcbasics.fth
@@ -6,7 +6,6 @@ fl ../arm-xo-1.75/smbus.fth
 
 fl ../arm-xo-1.75/addrs.fth
 
-: third  ( a b c -- a b c a )  2 pick  ;
 fl ../arm-mmp2/lcd.fth
 
 [ifdef] dcon-scl-gpio#

--- a/src/app/arm-xo-1.75/showpmu.fth
+++ b/src/app/arm-xo-1.75/showpmu.fth
@@ -46,7 +46,7 @@
    ." PJ_ISR     " h#   a0 p.8  ." MC_HW_SLP" h#   b0 p.8  ." MC_SLP_REQ " h#   b4 p.8  cr
    ." MC_SW_SLP  " h#   c0 p.8  ." PLL_SEL  " h#   c4 p.8  ." PWR_ONOFF  " h#   e0 p.8  cr
    ." PWR_TIMER  " h#   e4 p.8  ." MC_PAR   " h#  11c p.8  cr
-[ifdef] cl4
+[ifdef] mmp3
    \ some of these might exist on mmp2 as well
    ." CC2_PJ     " h#  150 p.8  ." CC3_PJ   " h#  188 p.8  ." DEBUG2     " h#  190 p.8 cr
 [then]
@@ -60,7 +60,7 @@
    ." CCIC2_RES  " h#   f4 p.8  ." HSI_RES  " h#  108 p.8  ." AUDIO_RES  " h#  10c p.8  cr
    ." DISP2_RES  " h#  110 p.8  ." CCIC2_RES" h#  118 p.8  ." ISP_RES    " h#  120 p.8  cr
    ." EPD_RES    " h#  124 p.8  ." APB2_RES " h#  134 p.8  cr
-[ifdef] cl4
+[ifdef] mmp3
    \ some of these might exist on mmp2 as well
    ." IDLE_CFG2  " h#  200 p.8  ." IDLE_CFG3" h#  204 p.8  ." ISL_POWER  " h#  220 p.8  cr
    ." ==Other Controls==" cr

--- a/src/app/arm-xo-cl4/app.fth
+++ b/src/app/arm-xo-cl4/app.fth
@@ -1,4 +1,4 @@
-create cl4  \ OLPC XO-CL4
+create mmp3  \ MMP3-based OLPC XO-CL4
 
 h#   10.0000 constant /rom
 h# 08fe.0000 constant dlofw-base

--- a/src/platform/arm-ariel/consoleio.c
+++ b/src/platform/arm-ariel/consoleio.c
@@ -1,0 +1,91 @@
+/*
+ * Ariel (Dell Wyse 3020) Console I/O
+ *
+ * Copyright (C) 2020 Lubomir Rintel <lkundrak@v3.sk>
+ *
+ * Based on src/platform/arm-xo-1.75/consoleio.c
+ */
+
+#include "forth.h"
+#include "compiler.h"
+
+#define UART3REG ((unsigned int volatile *)0xd4018000)
+
+int dbg_uart_only = 0;
+
+void txdbg(char c)
+{
+    while ((UART3REG[5] & 0x20) == 0)
+        ;
+    UART3REG[0] = (unsigned int)c;
+}
+
+void raw_putchar(char c)
+{
+    txdbg(c);
+}
+
+int kbhit3() {
+    return (UART3REG[5] & 0x1) != 0;
+}
+
+int kbhit() {
+    return kbhit3();
+}
+
+int getkey()
+{
+    do {
+        if (kbhit3())
+            return UART3REG[0];
+    } while (1);
+}
+
+void init_io(int argc, char **argv, cell *up)
+{
+    dbg_uart_only = 0;
+
+    // If the PJ4 processor has already been started, this is an unexpected
+    // reset so we skip the SoC init to preserve state for debugging.
+    if (((*(int *)0xd4050020) & 0x02) == 0)
+        return;
+
+    *(int *)0xd4051024 = 0xffffffff;    // PMUM_CGR_PJ - everything on
+    *(int *)0xd4015064 = 0x00000007;    // APBC_AIB_CLK_RST - reset, functional and APB clock on
+    *(int *)0xd4015064 = 0x00000003;    // APBC_AIB_CLK_RST - release reset, functional and APB clock on
+    *(int *)0xd4051020 = 0x00000000;    // PMUM_PRR_PJ - Turn off SLAVE_R and WDTR2 (empirically, the WDTR2 bit stays set afterwards)
+
+    *(int *)0xd401e120 = 0x00001001;    // GPIO51 = AF1 for UART3 RXD
+    *(int *)0xd401e124 = 0x00001001;    // GPIO52 = AF for UART3 TXD
+
+    *(int *)0xd4015034 = 0x00000013;    // APBC_UART3_CLK_RST - VCTCXO, functional and APB clock on (26 mhz)
+
+    UART3REG[1] = 0x40; // Marvell-specific UART Enable bit
+    UART3REG[3] = 0x83; // Divisor Latch Access bit
+    UART3REG[0] = 14;   // 115200 baud
+    UART3REG[1] = 00;   // 115200 baud
+    UART3REG[3] = 0x03; // 8n1
+    UART3REG[2] = 0x07; // FIFOs and stuff
+}
+
+void irq_handler()
+{
+}
+
+void swi_handler()
+{
+}
+
+void raise()
+{
+}
+
+int strlen(const char *s)
+{
+    const char *p;
+
+    for (p=s; *p != '\0'; *p++)
+        ;
+
+    return p-s;
+}

--- a/src/platform/arm-ariel/extend.c
+++ b/src/platform/arm-ariel/extend.c
@@ -1,0 +1,311 @@
+/* Based on src/platform/arm-xo-1.75/extend.c */
+
+#include "forth.h"
+
+void spi_read(cell offset, cell len, cell adr);
+cell inflate(cell wpptr, cell nohdr, cell clear, cell compr);
+cell dbg_uart_only;
+
+#define DECLARE_REGS \
+    volatile unsigned long *fifo = (volatile unsigned long *)0xd4035010; \
+    volatile unsigned long *stat = (volatile unsigned long *)0xd4035008
+
+void spi_send(cell len, cell adr)
+{
+    unsigned char *p = (char *)adr;
+    unsigned long regval;
+    DECLARE_REGS;
+    while (len--)
+        *fifo = (unsigned long)*p++;
+    do {
+        regval = *stat;
+    } while ((regval & 0xf04) != 4);
+}
+
+void spi_send_only(cell len, cell adr)
+{
+    unsigned char *p = (char *)adr;
+    unsigned long regval;
+    DECLARE_REGS;
+    int i;
+    for (i = len; i; i--)
+        *fifo = (unsigned long)*p++;
+    for (i = len; i; i--) {
+        while ((*stat & 8) == 0)
+            ;
+        regval = *fifo;
+    }
+}
+
+void spi_send_page(cell offset, cell len, cell adr)
+{
+    unsigned char *p = (char *)adr;
+    int cansend, i;
+    unsigned long regval;
+    DECLARE_REGS;
+
+    *fifo = 0x02;  // Page write
+    *fifo = (offset >> 16) & 0xff;
+    *fifo = (offset >>  8) & 0xff;
+    *fifo = offset & 0xff;
+
+    cansend = 12;
+    while (len) {
+        if (len < cansend)
+            cansend = len;
+
+        for (i = cansend; i; i--)
+            *(volatile unsigned long *)fifo = (unsigned long)*p++;
+
+        len -= cansend;
+
+        do {
+            regval = *stat;
+        } while ((regval & 4) == 0);
+        cansend = 16 - ((regval >> 8) & 0xf);
+    }
+    while ((*stat & 8) != 0)
+        regval = *fifo;
+}
+
+#define CHUNK 12
+void spi_read_slow(cell offset, cell len, cell adr)
+{
+    unsigned char *p = (char *)adr;
+    int cansend, i;
+    DECLARE_REGS;
+    unsigned long regval;
+    while (len) {
+        *fifo = 0x03;
+        *fifo = (offset >> 16) & 0xff;
+        *fifo = (offset >>  8) & 0xff;
+        *fifo = offset & 0xff;
+        cansend = (len < CHUNK) ? len : CHUNK;
+        for(i = cansend; i; i--) {
+            *fifo = 0;
+        }
+        for(i = 4; i; i--) {
+            while ((*stat & 8) == 0)
+                ;
+            regval = (unsigned char)*fifo;  // Discard readback from cmd and adr bytes
+        }
+
+        for(i = cansend; i; i--) {
+            while ((*stat & 8) == 0)
+                ;
+            *p++ = (unsigned char)*fifo;
+        }
+        len -= cansend;
+        offset += cansend;
+    }
+}
+
+void lfill(cell value, cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    while(len>0) {
+        *p++ = value;
+        len -= sizeof(long);
+    }
+}
+cell lcheck(cell value, cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    while(len>0) {
+        if (*p != value)
+            return (cell)p;
+        p++;
+        len -= sizeof(long);
+    }
+    return -1;
+}
+void incfill(cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    while(len>0) {
+        *p = (unsigned long)p;
+        p++;
+        len -= sizeof(long);
+    }
+}
+cell inccheck(cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    while(len>0) {
+        if (*p != (cell)p)
+            return (cell)p;
+        p++;
+        len -= sizeof(long);
+    }
+    return -1;
+}
+#define NEXTRAND(n) ((n*1103515245+12345) & 0x7fffffff)
+void randomfill(cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    unsigned long value = 0;
+    while(len>0) {
+        value = NEXTRAND(value);
+        *p = value;
+        p++;
+        len -= sizeof(long);
+    }
+}
+cell randomcheck(cell len, cell adr)
+{
+    unsigned long *p = (unsigned long *)adr;
+    unsigned long value = 0;
+    while(len>0) {
+        value = NEXTRAND(value);
+        if (*p != value)
+            return (cell)p;
+        p++;
+        len -= sizeof(long);
+    }
+    return -1;
+}
+
+
+cell spi_read_status()
+{
+    DECLARE_REGS;
+    unsigned long regval;
+    *fifo = 5;
+    *fifo = 0;
+    while ((*stat & 8) == 0) ;
+    regval = (unsigned char)*fifo;  // Discard readback from cmd byte
+    while ((*stat & 8) == 0) ;
+    return *fifo;
+}
+
+void set_control_reg(cell arg)
+{
+    __asm__ __volatile__ (
+        "mcr	p15, 0, %0, c1, c0, 0\n\t"
+        : : "r" (arg));
+}
+
+cell get_control_reg()
+{
+    unsigned long value;
+    __asm__ __volatile__ (
+        "mrc	p15, 0, %0, c1, c0, 0\n\t"
+        : "=r" (value));
+    return value;
+}
+
+cell get_tcm_size()
+{
+    unsigned long value;
+    __asm__ __volatile__ (
+        "mrc	p15, 0, %0, c0, c0, 2\n\t"
+        : "=r" (value));
+    return value;
+}
+
+cell inflate_adr(void)
+{
+    return (cell)inflate;
+}
+
+cell byte_checksum(cell len, cell adr)
+{
+    unsigned char *p = (unsigned char *)adr;
+    unsigned long value = 0;
+    while(len--) {
+        value += *p++;
+    }
+    return value;
+}
+
+cell wfi()
+{
+    __asm__ __volatile__ (" mcr  p15, 0, r0, c7, c0, 4");
+//        "wfi\n\t"
+//	    ".long 0xe320f003\n\t"  // wfi - which older assemblers don't support
+
+    return 0;
+}
+
+cell wfi_loop()
+{
+    while (1) {
+        __asm__ __volatile__ (" mcr  p15, 0, r0, c7, c0, 4");
+//        "wfi\n\t"
+//	    ".long 0xe320f003\n\t"  // wfi - which older assemblers don't support
+    }
+
+    return 0;
+}
+
+cell rdpsr()
+{
+    cell psrval;
+    __asm__ __volatile__ (
+	"mrs     %0, cpsr\n\t"
+	: "=r"(psrval)
+	:
+	);
+    return psrval;
+}
+cell wrpsr(cell psrval)
+{
+    __asm__ __volatile__ (
+	"msr     cpsr, %0"
+	:
+	:"r"(psrval)
+	);
+}
+
+cell one_uart_adr(void)
+{
+    return (cell)&dbg_uart_only;
+}
+cell reset_reason_val(void)
+{
+    extern cell reset_reason;
+    return reset_reason;
+}
+
+cell version_adr(void)
+{
+    extern char version[];
+    return (cell)version;
+}
+
+cell build_date_adr(void)
+{
+    extern char build_date[];
+    return (cell)build_date;
+}
+extern int kbhit3(void);
+
+cell ((* const ccalls[])()) = {
+  C(spi_send)        //c spi-send        { a.adr i.len -- }
+  C(spi_send_only)   //c spi-send-only   { a.adr i.len -- }
+  C(spi_read_slow)   //c spi-read-slow   { a.adr i.len i.offset -- }
+  C(spi_read_status) //c spi-read-status { -- i.status }
+  C(spi_send_page)   //c spi-send-page   { a.adr i.len i.offset -- }
+  C(spi_read)        //c spi-read        { a.adr i.len i.offset -- }
+  C(lfill)           //c lfill           { a.adr i.len i.value -- }
+  C(lcheck)          //c lcheck          { a.adr i.len i.value -- i.erraddr }
+  C(incfill)         //c inc-fill        { a.adr i.len -- }
+  C(inccheck)        //c inc-check       { a.adr i.len -- i.erraddr }
+  C(randomfill)      //c random-fill     { a.adr i.len -- }
+  C(randomcheck)     //c random-check    { a.adr i.len -- i.erraddr }
+  C(inflate)         //c (inflate)       { a.compadr a.expadr i.nohdr a.workadr -- i.expsize }
+  C(get_control_reg) //c control@        { -- i.value }
+  C(set_control_reg) //c control!        { i.value -- }
+  C(get_tcm_size)    //c tcm-size@       { -- i.value }
+  C(inflate_adr)     //c inflate-adr     { -- a.value }
+  C(byte_checksum)   //c byte-checksum   { a.adr i.len -- i.checksum }
+  C(wfi)             //c wfi             { -- }
+  C(rdpsr)           //c psr@            { -- i.value }
+  C(wrpsr)           //c psr!            { i.value -- }
+  C(one_uart_adr)    //c 'one-uart       { -- a.value }
+  C(reset_reason_val)//c reset-reason    { -- i.value }
+  C(version_adr)     //c 'version        { -- a.value }
+  C(build_date_adr)  //c 'build-date     { -- a.value }
+  C(wfi_loop)        //c wfi-loop        { -- }
+  C(kbhit3)          //c ukey3?          { -- i.value }
+};

--- a/src/platform/arm-ariel/targets.mk
+++ b/src/platform/arm-ariel/targets.mk
@@ -1,0 +1,93 @@
+# Makefile fragment for the final target application
+# Based on src/app/arm-xo-cl4/targets.mk
+
+SRC=$(TOPDIR)/src
+
+# Target compiler definitions
+CROSS ?= arm-none-eabi-
+CPU_VARIANT=-marm -mcpu=strongarm110
+include $(SRC)/cpu/arm/compiler.mk
+
+VPATH += $(SRC)/cpu/arm $(SRC)/lib
+VPATH += $(SRC)/platform/arm-ariel
+VPATH += $(SRC)/platform/arm-xo-1.75
+INCS += -I$(SRC)/platform/arm-ariel
+
+include $(SRC)/common.mk
+include $(SRC)/cforth/targets.mk
+include $(SRC)/cforth/embed/targets.mk
+
+TCFLAGS += -fno-pie
+
+DUMPFLAGS = --disassemble -z -x -s
+
+# Platform-specific object files for low-level startup and platform I/O
+
+PLAT_OBJS = tstart.o mallocembed.o
+
+# Object files for the Forth system and application-specific extensions
+
+# FORTH_OBJS = tmain.o embed.o textend.o  spiread.o consoleio.o
+FORTH_OBJS = ttmain.o tembed.o textend.o  tspiread-simpler.o tconsoleio.o tinflate.o
+
+SHIM_OBJS = tshimmain.o tspiread.o
+
+SHIM_CFLAGS += -DCFORTHSIZE=$(shell stat -c%s cforth.img)
+SHIM_CFLAGS += -DRAMBASE=$(RAMBASE)
+SHIM_CFLAGS += -DSHIMBASE=$(SHIMBASE)
+
+tshimmain.o: shimmain.c cforth.img
+	@echo TCC $<
+	@$(TCC) $(INCS) $(DEFS) $(TCFLAGS) $(TCPPFLAGS) $(SHIM_CFLAGS) -c $< -o $@
+
+# Recipe for linking the final image
+
+# On MMP3, a masked-ROM loader copies CForth from SPI FLASH into SRAM
+DICTIONARY=RAM
+
+DICTSIZE=0xf000
+
+RAMBASE  = 0xd1000000
+IRQSTACKSIZE = 0x100
+RAMTOP   = 0xd101f000
+SHIMBASE = 0xd1019000
+
+TSFLAGS += -DRAMTOP=${RAMTOP}
+TSFLAGS += -DIRQSTACKSIZE=${IRQSTACKSIZE}
+
+LIBGCC= -lgcc
+
+version:
+	git log -1 --format=format:"%H" >>$@ 2>/dev/null || echo UNKNOWN >>$@
+	pwd
+	echo VPATH = ${VPATH}
+
+cforth.elf: version $(PLAT_OBJS) $(FORTH_OBJS)
+	@echo 'const char version[] = "'`cat version`'" ;' >date.c
+	@echo 'const char build_date[] = "'`date --utc +%F\ %R`'" ;' >>date.c
+	@$(TCC) -c date.c
+	@echo Linking $@ ...
+	@$(TLD) -N  -o $@  $(TLFLAGS) -Ttext $(RAMBASE) \
+	    $(PLAT_OBJS) $(FORTH_OBJS) date.o \
+	    $(LIBDIRS) $(LIBGCC)
+	@$(TOBJDUMP) $(DUMPFLAGS) $@ >$(@:.elf=.dump)
+	@if egrep -q '^\S{8}:\s\S{4}\s' $(@:.elf=.dump); then echo 'PJ1 has no Thumb support. Wrong libgcc?'; rm $@; exit 1; fi
+	@nm -n $@ >$(@:.elf=.nm)
+
+shim.elf: $(PLAT_OBJS) $(SHIM_OBJS)
+	@echo Linking $@ ...
+	@$(TLD) -N  -o $@  $(TLFLAGS) -Ttext $(SHIMBASE) \
+	    $(PLAT_OBJS) $(SHIM_OBJS) \
+	    $(LIBDIRS) $(LIBGCC)
+	@$(TOBJDUMP) $(DUMPFLAGS) $@ >$(@:.elf=.dump)
+	@nm -n $@ >$(@:.elf=.nm)
+
+
+# This rule extracts the executable bits from an ELF file, yielding raw binary.
+
+%.img: %.elf
+	@$(TOBJCOPY) -O binary $< $@
+	@date  "+%F %H:%M" >>$@
+	@ls -l $@
+
+EXTRA_CLEAN += *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS) $(SHIM_OBJS) date.o version

--- a/src/platform/arm-xo-1.75/consoleio.c
+++ b/src/platform/arm-xo-1.75/consoleio.c
@@ -53,7 +53,7 @@ void txdbg(char c)
 {
     tx1(c);
 }
-void tx(char c)
+void raw_putchar(char c)
 {
     txdbg(c);
     if (dbg_uart_only)


### PR DESCRIPTION
This adds support for using CForth on the MMP3-based Ariel board, as
used in Dell Wyse 3020. It starts up on the small core and loads OFW
in a manner equivalent to what is done on OLPC CL4.

Among the differencies from CL4 are: diffrent DRAM, generally less
hardware hooked to GPIOs (no special keys, etc.), different EC,
and different display controller. The only UART that's routed to actual
connector on board is UART3 on pins 51 and 52.

The machine originally comes with proprietary "WLoader" firmware.
Running Open Firmware on it would make it suck considerably less.

