### PR TITLE
arm-xo-1.75: fix OLPC build

### DIFF
--- a/src/app/arm-xo-1.75/hackspi.fth
+++ b/src/app/arm-xo-1.75/hackspi.fth
@@ -184,7 +184,7 @@ h# 1010.0000 constant spi-mem-base
 : sec-trg  ( -- )  sec-trg-gpio# gpio-set  ;
 
 : protect-fw  ( -- )  secure?  if  spi-protect sec-trg  then  ;
-[endif]
+[then]
 
 \ Assumes offset is block-aligned
 : write-setup-dance  ( -- )


### PR DESCRIPTION
Oops, a brain fart. Sorry.

Fixes: d642a0994dea ("arm-xo-1.75: conditionalize protect-fw on sec-trg-gpio#")