### PR TITLE
riscv-gd32vf103: add GD32VF103 target

### DIFF
--- a/build/riscv-gd32vf103/Makefile
+++ b/build/riscv-gd32vf103/Makefile
@@ -1,0 +1,65 @@
+# Builds CForth for GD32VF103, for example "Polos Alef" boards
+
+# You need the GD32VF103 Firmware Library; see below for the URL
+
+# You also need the riscv-nuclei-elf- version of the gcc toolchain.
+# I got it from https://github.com/riscv-mcu/riscv-gnu-toolchain/releases
+# Its bin/ subdirectory must be in the search path
+
+TOPDIR = ../..
+
+MYNAME = riscv-gd32vf103
+
+CONFIG += -DBITS32 -DT16
+
+default: app.elf app.bin app.nm app.dump
+
+CROSS ?= $(GD32V_TOOLCHAIN)/bin/riscv-nuclei-elf-
+CPU_VARIANT ?= -march=rv32imac -mabi=ilp32 -mcmodel=medlow
+
+GD32V_TOOLCHAIN_PARENT_PATH = $(TOPDIR)/..
+GD32V_TOOLCHAIN ?= $(GD32V_TOOLCHAIN_PARENT_PATH)/rv_linux_bare_$(GD32V_TOOLCHAIN_VERSION)
+
+GD32V_TOOLCHAIN_VERSION ?= 1908312208
+GD32V_TOOLCHAIN_ARCHIVE = rv_linux_bare_$(GD32V_TOOLCHAIN_VERSION).tar.bz2
+GD32V_TOOLCHAIN_URL = https://github.com/riscv-mcu/riscv-gnu-toolchain/releases/download/v9.2RC/$(GD32V_TOOLCHAIN_ARCHIVE)
+
+GD32V_LIB_PARENT_PATH = $(TOPDIR)/..
+GD32V_LIB ?= $(GD32V_LIB_PARENT_PATH)/GD32VF103_Firmware_Library-$(GD32V_LIB_VERSION)
+
+GD32V_LIB_VERSION ?= 12b61d1bf29afbee8ec4eee81cdbf1bd9f89470a
+GD32V_LIB_ARCHIVE = GD32VF103_Firmware_Library-$(GD32V_LIB_VERSION).zip
+GD32V_LIB_URL = https://github.com/riscv-mcu/GD32VF103_Firmware_Library/archive/$(GD32V_LIB_VERSION)/$(GD32V_LIB_ARCHIVE)
+
+$(GD32V_LIB):
+	@echo Getting GD32VF103_Firmware_Library
+	(cd $(GD32V_LIB_PARENT_PATH) \
+	&& wget $(GD32V_LIB_URL) \
+	&& echo Unpacking GD32VF103_Firmware_Library \
+	&& unzip -q $(GD32V_LIB_ARCHIVE) \
+	&& rm $(GD32V_LIB_ARCHIVE) \
+	)
+
+$(GD32V_TOOLCHAIN):
+	@echo Getting riscv-gnu-toolchain
+	(cd $(GD32V_TOOLCHAIN_PARENT_PATH) \
+	&& wget $(GD32V_TOOLCHAIN_URL) \
+	&& echo Unpacking riscv-gnu-toolchain \
+	&& tar xjf $(GD32V_TOOLCHAIN_ARCHIVE) \
+	&& rm $(GD32V_TOOLCHAIN_ARCHIVE) \
+	)
+
+$(GD32V_TOOLCHAIN)/install-tools/macro_list: $(GD32V_TOOLCHAIN) $(GD32V_LIB)
+include $(GD32V_TOOLCHAIN)/install-tools/macro_list
+
+# The recipe for DFU flashing follows
+
+# The device needs to enter the DFU mode first, by starting with BOOT0=1
+# (typically a button on a board).
+
+DFU_UTIL = dfu-util
+
+flash: app.bin
+	$(DFU_UTIL) -d 28e9:0189 -a 0 -s 0x8000000:mass-erase:force:leave -D $<
+
+include $(TOPDIR)/src/app/$(MYNAME)/targets.mk

--- a/src/app/riscv-gd32vf103/app.fth
+++ b/src/app/riscv-gd32vf103/app.fth
@@ -1,0 +1,36 @@
+\ Load file for application-specific Forth extensions
+
+: bitset  ( mask adr -- )  tuck l@ or swap l!  ;
+: bitclr  ( mask adr -- )  tuck l@ swap invert and swap l!  ;
+
+0 constant gpioa
+1 constant gpiob
+2 constant gpioc
+3 constant gpiod
+4 constant gpioe
+
+\ GPIO modes.  This encoding matches the GD32VF103 Firmware Library
+$00 constant ain
+
+$10 constant out_pp
+$14 constant out_od
+
+$18 constant af_pp
+$1c constant af_od
+
+$04 constant in_floating
+$28 constant in_pulldown
+$48 constant in_pullup
+
+0 value led-gpio
+: init-led  ( -- )
+   out_pp #13 gpioc gpio-open to led-gpio
+;
+: led-on  ( -- )  led-gpio gpio-set  ;
+: led-off ( -- )  led-gpio gpio-clr  ;
+
+\ Replace 'quit' to make CForth auto-run some application code
+\ instead of just going interactive.
+: app  ." CForth (GD32VF103)" cr hex quit  ;
+
+" app.dic" save

--- a/src/app/riscv-gd32vf103/targets.mk
+++ b/src/app/riscv-gd32vf103/targets.mk
@@ -1,0 +1,11 @@
+# APPPATH is the path to the application code, i.e. this directory
+APPPATH=$(TOPDIR)/src/app/$(MYNAME)
+
+# APPLOADFILE is the top-level "Forth load file" for the application code.
+APPLOADFILE = app.fth
+
+# APPSRCS is a list of Forth source files that the application uses,
+# i.e. the list of files that APPLOADFILE floads.  It's for dependency checking.
+APPSRCS = $(wildcard $(APPPATH)/*.fth)
+
+include $(TOPDIR)/src/platform/$(MYNAME)/targets.mk

--- a/src/cpu/riscv/compiler.mk
+++ b/src/cpu/riscv/compiler.mk
@@ -1,0 +1,9 @@
+# allow override of default cross location
+CROSS ?= riscv64-linux-gnu-
+TCC=$(CROSS)gcc
+TLD=$(CROSS)ld
+TOBJDUMP=$(CROSS)objdump
+TOBJCOPY=$(CROSS)objcopy
+
+TCFLAGS += $(CPU_VARIANT)
+TSFLAGS += $(CPU_VARIANT)

--- a/src/platform/riscv-gd32vf103/consoleio.c
+++ b/src/platform/riscv-gd32vf103/consoleio.c
@@ -1,0 +1,49 @@
+// Character I/O stubs
+
+#include "gd32vf103_libopt.h"
+
+uint32_t consoleUart;
+
+void raw_putchar(char ch)
+{
+	usart_data_transmit(consoleUart, ch);
+	while (usart_flag_get(consoleUart, USART_FLAG_TBE) == RESET);
+}
+
+int kbhit() {
+	return usart_flag_get(consoleUart, USART_FLAG_RBNE);
+}
+
+int getkey()
+{
+	while (!kbhit());
+	return usart_data_receive(consoleUart);
+}
+
+void init_io()
+{
+	consoleUart = USART0;
+
+	rcu_periph_clock_enable(RCU_GPIOA);
+	rcu_periph_clock_enable(RCU_USART0);
+
+	gpio_init(GPIOA, GPIO_MODE_AF_PP, GPIO_OSPEED_50MHZ, GPIO_PIN_9);
+	gpio_init(GPIOA, GPIO_MODE_IN_FLOATING, GPIO_OSPEED_50MHZ, GPIO_PIN_10);
+
+	usart_deinit(consoleUart);
+	usart_baudrate_set(consoleUart, 115200U);
+	usart_word_length_set(consoleUart, USART_WL_8BIT);
+	usart_stop_bit_set(consoleUart, USART_STB_1BIT);
+	usart_parity_config(consoleUart, USART_PM_NONE);
+	usart_hardware_flow_rts_config(consoleUart, USART_RTS_DISABLE);
+	usart_hardware_flow_cts_config(consoleUart, USART_CTS_DISABLE);
+	usart_receive_config(consoleUart, USART_RECEIVE_ENABLE);
+	usart_transmit_config(consoleUart, USART_TRANSMIT_ENABLE);
+	usart_enable(consoleUart);
+}
+
+// These would drag in obsecenely large "impure_data" symbol from the libc
+void exit(int status) { while(1); }
+void atexit() {}
+void handle_nmi() {}
+void handle_trap() {}

--- a/src/platform/riscv-gd32vf103/extend.c
+++ b/src/platform/riscv-gd32vf103/extend.c
@@ -1,0 +1,22 @@
+// Edit this file to include C routines that can be called as Forth words.
+// See "ccalls" below.
+
+#include "forth.h"
+#include "systick.h"
+
+// Prototypes
+
+void gpio_open();
+void gpio_set();
+void gpio_clr();
+void gpio_write();
+void gpio_read();
+
+cell ((* const ccalls[])()) = {
+	C(delay_1ms)    //c ms         { i.nmsecs -- }
+	C(gpio_open)    //c gpio-open  { i.mode i.pin i.port -- i.portpin }
+	C(gpio_set)     //c gpio-set   { i.portpin -- }
+	C(gpio_clr)     //c gpio-clr   { i.portpin -- }
+	C(gpio_write)   //c gpio-pin!  { i.value i.portpin -- }
+	C(gpio_read)    //c gpio-pin@  { i.portpin -- i.value }
+};

--- a/src/platform/riscv-gd32vf103/gpio.c
+++ b/src/platform/riscv-gd32vf103/gpio.c
@@ -1,0 +1,62 @@
+#include "gd32vf103_libopt.h"
+#include "systick.h"
+
+rcu_periph_enum gpio_clocks[] = {
+        RCU_GPIOA,
+        RCU_GPIOB,
+        RCU_GPIOC,
+        RCU_GPIOD,
+        RCU_GPIOE,
+};
+
+uint32_t gpio_ports[] = {
+        GPIOA,
+        GPIOB,
+        GPIOC,
+        GPIOD,
+        GPIOE,
+};
+
+int gpio_open(unsigned int portno, unsigned int pin, int mode)
+{
+	if (portno >= sizeof(gpio_ports) / sizeof(gpio_ports[0]))
+		return 0;
+
+	uint32_t portp = gpio_ports[portno];
+
+	if (pin > 15)
+		return 0;
+
+	rcu_periph_clock_enable(gpio_clocks[portno]);
+	gpio_init(gpio_ports[portno], mode, GPIO_OSPEED_50MHZ, 1 << pin);
+
+	return (int)portp + pin;
+}
+
+void gpio_set(int portpin)
+{
+	uint32_t port = (uint32_t)(portpin & ~0x0f);
+	int pin = portpin & 0x0f;
+	gpio_bit_set(port, 1 << pin);
+}
+
+void gpio_clr(int portpin)
+{
+	uint32_t port = (uint32_t)(portpin & ~0x0f);
+	int pin = portpin & 0x0f;
+	gpio_bit_reset(port, 1 << pin);
+}
+
+void gpio_write(int portpin, int value)
+{
+	uint32_t port = (uint32_t)(portpin & ~0x0f);
+	int pin = portpin & 0x0f;
+	gpio_bit_write(port, 1 << pin, !!value);
+}
+
+int gpio_read(int portpin)
+{
+	uint32_t port = (uint32_t)(portpin & ~0x0f);
+	int pin = portpin & 0x0f;
+	return gpio_input_bit_get(port, 1 << pin) == RESET ? 0 : -1;
+}

--- a/src/platform/riscv-gd32vf103/targets.mk
+++ b/src/platform/riscv-gd32vf103/targets.mk
@@ -1,0 +1,120 @@
+# Makefile fragment for the final target application
+
+SRC=$(TOPDIR)/src
+
+# Target compiler definitions
+include $(SRC)/cpu/riscv/compiler.mk
+
+DEFS += -DUSE_STDPERIPH_DRIVER
+DEFS += -DHXTAL_VALUE=8000000U
+
+DICTIONARY = ROM
+
+ifneq ($(findstring FLOATING,$(CONFIG)),)
+	DICTSIZE ?= 0x3000
+else
+	DICTSIZE ?= 0x4000
+	TLFLAGS += -lm
+endif
+
+CFLAGS += -m32 -march=i386
+
+TCFLAGS += -Os
+
+# Omit unreachable functions from output
+
+TCFLAGS += -ffunction-sections -fdata-sections
+TLFLAGS += -Wl,--gc-sections
+TLFLAGS += -Wl,--defsym -Wl,__stack_size=0x80
+
+VPATH += $(SRC)/platform/$(MYNAME)
+VPATH += $(SRC)/lib
+VPATH += $(SRC)/cforth
+VPATH += $(GD32V_LIB)/Firmware/GD32VF103_standard_peripheral/Source
+VPATH += $(GD32V_LIB)/Firmware/GD32VF103_standard_peripheral
+VPATH += $(GD32V_LIB)/Firmware/RISCV/stubs
+VPATH += $(GD32V_LIB)/Firmware/RISCV/drivers
+VPATH += $(GD32V_LIB)/Firmware/RISCV/env_Eclipse
+VPATH += $(GD32V_LIB)/Template
+
+# This directory, including board information
+INCS += -I$(SRC)/platform/$(MYNAME)
+
+INCS += -I$(GD32V_LIB)/Firmware/GD32VF103_standard_peripheral/Include
+INCS += -I$(GD32V_LIB)/Firmware/GD32VF103_standard_peripheral
+INCS += -I$(GD32V_LIB)/Firmware/RISCV/drivers
+INCS += -I$(GD32V_LIB)/Template
+
+include $(SRC)/common.mk
+include $(SRC)/cforth/targets.mk
+
+# Platform-specific object files for low-level startup and platform I/O
+
+PLAT_OBJS += tsystem_gd32vf103.o
+PLAT_OBJS += tgd32vf103_usart.o
+PLAT_OBJS += tgd32vf103_rcu.o
+PLAT_OBJS += tgd32vf103_gpio.o
+PLAT_OBJS += tsystick.o
+PLAT_OBJS += twrite.o
+
+PLAT_OBJS += tn200_func.o
+PLAT_OBJS += tstart.o
+PLAT_OBJS += tentry.o
+PLAT_OBJS += thandlers.o
+PLAT_OBJS += tinit.o
+
+PLAT_OBJS += ttmain.o
+PLAT_OBJS += mallocembed.o
+PLAT_OBJS += tconsoleio.o
+PLAT_OBJS += tgpio.o
+
+ttmain.o: vars.h
+
+# EXTEND_OBJS ?= ti2c.o
+
+PLAT_OBJS += $(EXTEND_OBJS)
+
+# Object files for the Forth system and application-specific extensions
+
+FORTH_OBJS = tembed.o textend.o
+
+# Recipe for linking the final image
+
+# 16k Flash, 6k RAM -- too small
+#LDSCRIPT = $(GD32V_LIB)/Firmware/RISCV/env_Eclipse/GD32VF103x4.lds
+# 32k Flash, 10k RAM -- too small
+#LDSCRIPT = $(GD32V_LIB)/Firmware/RISCV/env_Eclipse/GD32VF103x6.lds
+# 64k Flash, 20k RAM -- Sipeed Longan Nano Lite
+#LDSCRIPT = $(GD32V_LIB)/Firmware/RISCV/env_Eclipse/GD32VF103x8.lds
+# 128k Flash, 32k RAM -- GD32VF103V-EVAL, Sipeed Longan Nano,
+# Wio Lite RISC-V, Polos Alef
+LDSCRIPT = $(GD32V_LIB)/Firmware/RISCV/env_Eclipse/GD32VF103xB.lds
+
+LDCMD := $(TCC) $(CPU_VARIANT) $(TLFLAGS) \
+	 -T$(LDSCRIPT) $(PLAT_OBJS) $(FORTH_OBJS) \
+	 -nostartfiles -specs=nosys.specs
+
+app.elf: $(PLAT_OBJS) $(FORTH_OBJS)
+	@echo Linking $@ ...
+	$(LDCMD) -o $@
+
+
+# This rule extracts the executable bits from an ELF file, yielding raw binary.
+
+%.img: %.elf
+	@$(TOBJCOPY) -O binary $< $@
+	date  "+%F %H:%M" >>$@
+	@ls -l $@
+
+# Override the default .dump rule to include the interrupt vector table
+
+%.dump: %.elf
+	@$(TOBJDUMP) -s -j .init $< >$@
+	@$(TOBJDUMP) --disassemble $< >>$@
+
+# This rule builds a date stamp object that you can include in the image
+# if you wish.
+
+EXTRA_CLEAN += *.bin *.elf *.dump *.nm *.img date.c $(FORTH_OBJS) $(PLAT_OBJS)
+
+include $(SRC)/cforth/embed/targets.mk

--- a/src/platform/riscv-gd32vf103/tmain.c
+++ b/src/platform/riscv-gd32vf103/tmain.c
@@ -1,0 +1,13 @@
+// Top-level routine for starting Forth
+
+#include "forth.h"
+#include "compiler.h"
+
+int main()
+{
+	cell *up;
+	init_io(0, (char **)0, (cell *)up);   // Perform platform-specific initialization
+	up = (void *)init_forth();
+	execute_word("app", up);  // Call the top-level application word
+	while(1);
+}


### PR DESCRIPTION
This adds a very basic support for a MCU with STM32-compatible peripherals
and a 32-bit RISC-V core. Loosely based on based on arm-stm32f2013. The
peripheral driver library has a somewhat different interface though.

Tested by blinking a led on a Polos Alef R1 board, though my friends and
family didn't appreciate it nearly as much as I did.