### PR TITLE
Fix ccalls.fth dependency miss

### DIFF
--- a/src/cforth/io.c
+++ b/src/cforth/io.c
@@ -214,7 +214,7 @@ void init_io(int argc, char **argv, cell *up)
         input_file = stdin;
         title(up);
     } else {
-        input_file = open_next_file();
+        input_file = open_next_file(up);
     }
     if (input_file == (FILE *)0) {
         FTHERROR("No input stream\n");

--- a/src/cforth/targets.mk
+++ b/src/cforth/targets.mk
@@ -136,7 +136,7 @@ forth: $(BASEOBJS) $(HOSTOBJS)
 # and file I/O.  It is used in the compilation tools but not in the
 # embeddable version (embed.o).
 
-extend.o: $(EXTENDSRC) $(FINC) makeccalls
+extend.o ccalls.fth: $(EXTENDSRC) $(FINC) makeccalls
 	@echo CC $<
 	@$(CC) $(CFLAGS) -c $(EXTENDSRC) -o $@
 	@$(CC) $(CFLAGS) -E -C -c $(EXTENDSRC) | ./makeccalls >ccalls.fth


### PR DESCRIPTION
While relearning the build steps for `host-serial-linux64`, removing occasional files and restarting, I did find a way to break it.  Then I fixed it.  :grin: