### PR TITLE
Jos: Additions for calls for an extra uart and lwip-recv-r 

### DIFF
--- a/build/esp32/sdk_build/main/interface.c
+++ b/build/esp32/sdk_build/main/interface.c
@@ -591,7 +591,28 @@ void restart(void)
 }
 
 #include <rom/ets_sys.h>
-void us(cell us)
+void IRAM_ATTR us(cell us)
 {
     ets_delay_us(us);
+}
+
+int IRAM_ATTR time_t_now()
+{
+struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
+         gettimeofday(&tv, NULL);
+return tv.tv_sec*(uint64_t)1000000+tv.tv_usec;
+}
+
+int IRAM_ATTR time_t_ms()
+{
+struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
+         gettimeofday(&tv, NULL);
+return tv.tv_sec*(uint64_t)1000+tv.tv_usec/1000;
+}
+
+int IRAM_ATTR time_t_sec()
+{
+struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
+         gettimeofday(&tv, NULL);
+return tv.tv_sec;
 }

--- a/build/esp32/sdk_build/main/interface.c
+++ b/build/esp32/sdk_build/main/interface.c
@@ -69,6 +69,24 @@ void init_uart(void)
     uart_driver_install(uart_num, BUF_SIZE * 2, 0, 0, NULL, 0);
 }
 
+cell my_uart_param_config(int uart_num, int baud, int bits, int par, int stop, int flow)
+{
+    uart_config_t uart_config = {
+       .baud_rate = baud,
+       .data_bits = bits-5,
+       .parity = par,
+       .stop_bits = stop,
+       .flow_ctrl = flow,
+       .rx_flow_ctrl_thresh = 122,
+    };
+   return uart_param_config(uart_num, &uart_config);
+}
+
+cell my_lwip_recv_r(int handle, int size, void *buf, int flags)
+{
+ return lwip_recv_r(handle, buf, size, flags);
+}
+
 // Routines for the ccalls[] table in textend.c.  Add new ones
 // as necessary.
 
@@ -389,7 +407,6 @@ int client_socket(char *host, char *portstr, cell protocol)
             cause = "socket";
             continue;
         }
-
         if (connect(s, res->ai_addr, res->ai_addrlen) < 0) {
             cause = "connect";
             close(s);
@@ -411,7 +428,6 @@ cell udp_client(char *host, char *portstr)
 {
     return client_socket(host, portstr, SOCK_DGRAM);
 }
-
 
 int stream_connect(char *host, char *portstr, int timeout_msecs)
 {

--- a/src/app/esp32/app.fth
+++ b/src/app/esp32/app.fth
@@ -28,8 +28,24 @@ alias m-init noop
    key?  if  key true exit  then
    false
 ;
-alias get-ticks get-msecs
-: ms>ticks  ( ms -- ticks )  ;
+
+: ms>ticks  ( ms -- ticks )
+   esp-clk-cpu-freq #80000000 over =
+     if    drop
+     else  #240000000 =
+             if   exit
+             else #1 lshift
+             then
+     then  #3 /
+;
+
+: ms ( ms - )
+   get-msecs +
+     begin   dup get-msecs - #10000 >
+     while   #10000000 us
+     repeat
+   get-msecs - #1000 * 0 max us
+;
 
 fl wifi.fth
 

--- a/src/app/esp32/extend.c
+++ b/src/app/esp32/extend.c
@@ -57,7 +57,6 @@ extern void mcpwm_set_signal_low(void);
 extern void mcpwm_start(void);
 extern void mcpwm_stop(void);
 extern void esp_deep_sleep_start(void);
-// 19-12
 extern void esp_sleep_enable_ext0_wakeup(void);
 extern void esp_wifi_restore(void);
 extern void esp_clk_cpu_freq(void);
@@ -66,9 +65,14 @@ extern void esp_wifi_start(void);
 extern void esp_wifi_stop(void);
 extern void adc_power_on(void);
 extern void adc_power_off(void);
-
 extern void gpio_intr_enable(void);
 extern void gpio_intr_disable(void);
+extern void my_uart_param_config(void);
+extern void uart_set_pin(void);
+extern void uart_driver_install(void);
+extern void uart_write_bytes(void);
+extern void uart_read_bytes(void);
+extern void my_lwip_recv_r(void);
 
 int xTaskGetTickCount(void);
 void raw_emit(char c);
@@ -264,6 +268,12 @@ cell ((* const ccalls[])()) = {
  C(esp_adc_cal_check_efuse)     //c check-efuse   { i.type -- i.res }
 	C(hall_sensor_read)     //c hall@         { -- i.voltage }
 
+	C(my_uart_param_config)	//c uart-param-config	{ i.flow i.stop i.par i.#bits i.baud i.uart_num -- i.err}
+	C(uart_write_bytes)	//c uart-write-bytes	{ i.size a.src i.uart_num -- i.res }
+	C(uart_read_bytes)	//c uart-read-bytes	{ i.wait i.size i.buf i.uart_num - i.#bytes }
+	C(uart_set_pin)		//c uart-set-pin	{ i.cts i.rts i.rx i.tx i.uart_num -- i.error? }
+	C(uart_driver_install)	//c uart-driver-install	{ i.flags a.queue i.q_size i.tx_size i.rx_size i.uart_num -- i.error? }
+
 	C(i2c_open)		//c i2c-open   { i.scl i.sda -- i.error? }
 	C(i2c_close)		//c i2c-close  { -- }
 	C(i2c_write_read)	//c i2c-write-read { a.wbuf i.wsize a.rbuf i.rsize i.slave i.stop -- i.err? }
@@ -294,12 +304,14 @@ cell ((* const ccalls[])()) = {
   // LWIP sockets
   // Like Posix sockets but the socket descriptor space is not
   // merged with the file descriptor space, so you cannot
-  // do a select that encompasses both
+  // do a  that encompasses both
 	C(lwip_socket)		//c socket         { i.proto i.type i.family -- i.handle }
 	C(lwip_bind_r)		//c bind           { i.len a.addr i.handle -- i.error }
 	C(lwip_setsockopt_r)	//c setsockopt     { i.len a.addr i.optname i.level i.handle -- i.error }
 	C(lwip_getsockopt_r)	//c getsockopt     { i.len a.addr i.optname i.level i.handle -- i.error }
 	C(lwip_connect_r)	//c connect        { i.len a.adr i.handle -- i.error }
+	C(my_lwip_recv_r)	//c lwip-recv-r	   { i.flags a.buf i.size i.handle -- i.count }
+
 	C(stream_connect)	//c stream-connect { i.timeout $.portname $.hostname -- i.handle }
 	C(udp_client)		//c udp-connect    { $.portname $.hostname -- i.handle }
 	C(my_lwip_write)	//c lwip-write     { a.buf i.size i.handle -- i.count }
@@ -335,8 +347,8 @@ cell ((* const ccalls[])()) = {
         C(mcpwm_init)            //c mcpwm_init  { a.conf i.timer# i.pwm# -- e.err? }
         C(mcpwm_set_frequency)   //c mcpwm_set_frequency  { i.freq i.timer# i.pwm# -- e.err? }
         C(mcpwm_set_duty_in_us)  //c mcpwm_set_duty_in_us  { i.duty i.op# i.timer# i.pwm# -- e.err? }
-C(mcpwm_set_duty_type)           //c mcpwm_set_duty_type { i.duty# i.op# i.timer# i.pwm# -- i.err? }
-C(mcpwm_get_frequency)           //c mcpwm_get_frequency { i.timer# i.pwm# -- i.freq }
+	C(mcpwm_set_duty_type)	 //c mcpwm_set_duty_type { i.duty# i.op# i.timer# i.pwm# -- i.err? }
+	C(mcpwm_get_frequency)	 //c mcpwm_get_frequency { i.timer# i.pwm# -- i.freq }
         C(mcpwm_set_signal_high) //c mcpwm_set_signal_high { i.op# i.timer# i.pwm# -- i.err? }
         C(mcpwm_set_signal_low)  //c mcpwm_set_signal_low { i.op# i.timer# i.pwm# -- i.err? }
         C(mcpwm_start)           //c mcpwm_start { i.timer# i.pwm# -- i.err? }

--- a/src/app/esp32/tests/uart_test.fth
+++ b/src/app/esp32/tests/uart_test.fth
@@ -1,0 +1,20 @@
+0 value uart_num   #130 value /RxBuf   0   value &RxBuf
+/RxBuf  allocate drop to &RxBuf
+
+: send-tx ( adr cnt -  )
+   tuck swap uart_num uart-write-bytes <> abort" uart-write-bytes failed" ;
+
+: read-rx ( - #read )  0 /RxBuf &RxBuf uart_num  uart-read-bytes ;
+
+-1 constant UART_PIN_NO_CHANGE
+
+: init-extra-uart ( rx-pin tx-pin uart_num -- )
+    to uart_num 2>r
+    0 1 0 8 115200 uart_num uart-param-config
+          abort" uart-param-config failed"
+    UART_PIN_NO_CHANGE UART_PIN_NO_CHANGE 2r> uart_num uart-set-pin
+          abort" uart-set-pin failed"
+    0 0 0 0 /RxBuf uart_num uart-driver-install
+          abort" uart-driver-install failed" ;
+
+#26 #25 2 init-extra-uart

--- a/src/cforth/environ.fth
+++ b/src/cforth/environ.fth
@@ -2,6 +2,7 @@
 
 vocabulary environment  environment definitions
 
+true constant cforth 
 #align constant /align
 1 chars constant /char
 td 255 constant /counted-string


### PR DESCRIPTION
Added calls for an extra uart
my_uart_param_config, uart_write_bytes	  
uart_read_bytes, uart_set_pin, uart_driver_install 
for the use of an extra uart. 
See ~/cforth/src/app/esp32/tests

Added: lwip-recv-r to avoid hanging connections.
Possible use: 

$08 constant MSG_DONTWAIT

: recv { sock -- length }
    0 10 0
       do  MSG_DONTWAIT req-buf /req-buf sock lwip-recv-r dup 0>
             if    nip leave
             else  drop
             then
           50 ms
       loop ;