### PR TITLE
Improved the handling of time and esp-now

### DIFF
--- a/build/esp32-extra/sdk_build/main/interface.c
+++ b/build/esp32-extra/sdk_build/main/interface.c
@@ -528,6 +528,11 @@ char *expand_path(char *name)
     return path;
 }
 
+void my_spiffs_unmount(void)
+{
+    spiffs_unmount(0);
+}
+
 void *open_dir(void)
 {
     return opendir(expand_path(""));
@@ -591,23 +596,16 @@ void IRAM_ATTR us(cell us)
     ets_delay_us(us);
 }
 
-int IRAM_ATTR time_t_now()
+int IRAM_ATTR get_system_time(struct timeval *tp)
 {
 struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
-         gettimeofday(&tv, NULL);
-return tv.tv_sec*(uint64_t)1000000+tv.tv_usec;
+        gettimeofday(&tv, NULL);
+        *tp = tv;
+        return 0;
 }
 
-int IRAM_ATTR time_t_ms()
+void set_system_time(cell sec)
 {
-struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
-         gettimeofday(&tv, NULL);
-return tv.tv_sec*(uint64_t)1000+tv.tv_usec/1000;
-}
-
-int IRAM_ATTR time_t_sec()
-{
-struct timeval tv = { .tv_sec = 0, .tv_usec = 0 };
-         gettimeofday(&tv, NULL);
-return tv.tv_sec;
+struct timeval tv = { .tv_sec =  sec };
+         settimeofday(&tv,NULL);
 }

--- a/src/app/esp32-extra/app.fth
+++ b/src/app/esp32-extra/app.fth
@@ -39,12 +39,37 @@ alias m-init noop
      then  #3 /
 ;
 
-: ms ( ms - )
-   get-msecs +
-     begin   dup get-msecs - #10000 >
-     while   #10000000 us
+ f# 0 fvalue us-start   \ Must be updated after set-system-time
+
+: system-time>f ( us seconds -- ) ( f: -- us )
+   s" s>d d>f f# 1000000 f*  s>d d>f  f+ "  evaluate ; immediate
+
+: usf@         ( f: -- us )
+   s" dup dup sp@ get-system-time! system-time>f" evaluate ; immediate
+
+: ms@         ( -- ms )
+   f# .001 usf@ us-start f- f* f>d drop ;
+
+alias get-msecs ms@
+
+: ms ( ms -- )
+   s>d d>f f# 1000 f* usf@  f+
+     begin   fdup  usf@  f- f# 100000000 f>
+     while   #100000000 us
      repeat
-   get-msecs - #1000 * 0 max us
+   usf@  f- f>d drop abs us
+;
+
+fl wifi.fth
+
+alias get-msecs ms@
+
+: ms ( ms -- )
+   s>d d>f f# 1000 f* usf@  f+
+     begin   fdup  usf@  f- f# 100000000 f>
+     while   #100000000 us
+     repeat
+   usf@  f- f>d d>s 0 max us
 ;
 
 fl wifi.fth
@@ -57,26 +82,39 @@ also modem
 previous
 
 fl files.fth
-
 fl server.fth
+fl tasking_rtos.fth        \ Preemptive multitasking
 
-fl tasking_rtos.fth         \ Preemptive multitasking
+fl tools/extra.fth
+fl tools/table_sort.f
+fl tools/timediff.fth      \ Time calculations.
+fl tools/webcontrols.fth   \ Extra tags in ROM
+fl tools/svg_plotter.f
+fl tools/rcvfile.fth
+fl tools/wsping.fth
+fl tools/schedule-tool.f   \ Daily schedule
+fl ../ntc-web/ntc_steinhart.fth  \ For ntc_web.fth
 
 
-\ Replace 'quit' to make CForth auto-run some application code
-\ instead of just going interactive.
-\ : app  banner  hex init-i2c  showstack  quit  ;
 : interrupt?  ( -- flag )
    ." Type a key within 2 seconds to interact" cr
-   #20 0  do  key?  if  key drop  true unloop exit  then  #100 ms  loop
+   #20 0  do  #100 ms  key?  if  key drop  true unloop exit  then   loop
    false
 ;
-: load-startup-file  ( -- )  " start" included   ;
 
-: app
-   banner  hex
-   interrupt?  if  quit  then
-   ['] load-startup-file catch drop
+: load-startup-file  ( -- ior )   " start" ['] included catch   ;
+
+: app ( - ) \ Sometimes SPIFFS or a wifi connection causes an error. A reboot solves that.
+   usf@ to us-start
+   banner  hex  interrupt? 0=
+      if     s" start" file-exist?
+           if   load-startup-file
+                if   ." Reading SPIFFS. " cr interrupt? 0=
+                    if    reboot
+                    then
+                then
+           then
+      then
    quit
 ;
 

--- a/src/app/esp32-extra/app.fth
+++ b/src/app/esp32-extra/app.fth
@@ -62,18 +62,6 @@ alias get-msecs ms@
 
 fl wifi.fth
 
-alias get-msecs ms@
-
-: ms ( ms -- )
-   s>d d>f f# 1000 f* usf@  f+
-     begin   fdup  usf@  f- f# 100000000 f>
-     while   #100000000 us
-     repeat
-   usf@  f- f>d d>s 0 max us
-;
-
-fl wifi.fth
-
 fl ../esp8266/xmifce.fth
 fl ../../lib/crc16.fth
 fl ../../lib/xmodem.fth
@@ -84,17 +72,7 @@ previous
 fl files.fth
 fl server.fth
 fl tasking_rtos.fth        \ Preemptive multitasking
-
 fl tools/extra.fth
-fl tools/table_sort.f
-fl tools/timediff.fth      \ Time calculations.
-fl tools/webcontrols.fth   \ Extra tags in ROM
-fl tools/svg_plotter.f
-fl tools/rcvfile.fth
-fl tools/wsping.fth
-fl tools/schedule-tool.f   \ Daily schedule
-fl ../ntc-web/ntc_steinhart.fth  \ For ntc_web.fth
-
 
 : interrupt?  ( -- flag )
    ." Type a key within 2 seconds to interact" cr

--- a/src/app/esp32-extra/extend.c
+++ b/src/app/esp32-extra/extend.c
@@ -63,6 +63,7 @@ extern void esp_clk_cpu_freq(void);
 extern void rtc_clk_cpu_freq_set(void);
 extern void esp_wifi_start(void);
 extern void esp_wifi_stop(void);
+extern void esp_wifi_disconnect(void);
 extern void adc_power_on(void);
 extern void adc_power_off(void);
 extern void gpio_intr_enable(void);
@@ -72,9 +73,8 @@ extern void uart_set_pin(void);
 extern void uart_driver_install(void);
 extern void uart_write_bytes(void);
 extern void uart_read_bytes(void);
-extern void time_t_now(void);
-extern void time_t_ms(void);
-extern void time_t_sec(void);
+extern void get_system_time(void);
+extern void set_system_time(void);
 extern void my_spiffs_unmount(void);
 
 int xTaskGetTickCount(void);
@@ -251,9 +251,8 @@ cell ((* const ccalls[])()) = {
 	C(build_date_adr)       //c 'build-date     { -- a.value }
 	C(version_adr)          //c 'version        { -- a.value }
         C(us)                   //c us		    { i.us -- }
-	C(time_t_now)           //c us@             { -- i.us }
-	C(time_t_ms)		//c get-msecs       { -- i.ms }
-	C(time_t_sec)		//c get-secs        { -- i.seconds }
+	C(set_system_time)      //c set-system-time { i.seconds -- }
+	C(get_system_time)      //c get-system-time! { a.2var_timeval -- }
 	C(xTaskGetTickCount)    //c get-ticks       { -- i.ticks }
 	C(software_reset)       //c restart         { -- }
 	C(set_log_level)	//c log-level!	    { i.level $component -- }
@@ -302,6 +301,7 @@ cell ((* const ccalls[])()) = {
 	C(wifi_open)		//c wifi-open { $ssid $password i.timeout -- i.error? }
  	C(esp_wifi_start)       //c esp-wifi-start             { -- }
  	C(esp_wifi_stop)        //c esp-wifi-stop              { -- }
+ 	C(esp_wifi_disconnect)  //c esp-wifi-disconnect        { -- }
 
   // LWIP sockets
   // Like Posix sockets but the socket descriptor space is not

--- a/src/app/esp32-extra/tools/rcvfile.fth
+++ b/src/app/esp32-extra/tools/rcvfile.fth
@@ -1,4 +1,4 @@
-marker -rcvfile.fth  cr lastacf .name #19 to-column  .( 17-07-2023 ) \ By J.v.d.Ven
+marker -rcvfile.fth  cr lastacf .name #19 to-column  .( 11-11-2023 ) \ By J.v.d.Ven
 \ To receive an ASCII file over a wifi connection
 
 \ Needed in ROM

--- a/src/app/esp32-extra/tools/svg_plotter.f
+++ b/src/app/esp32-extra/tools/svg_plotter.f
@@ -1,4 +1,4 @@
-marker svg_plotter.f  cr lastacf .name #19 to-column .( 05-01-2023 ) \ By J.v.d.Ven
+marker -svg_plotter.f  cr lastacf .name #19 to-column .( 11-11-2023 ) \ By J.v.d.Ven
  \ To plot simple charts for a web client
 
 needs /circular      extra.fth

--- a/src/app/esp32-extra/tools/webcontrols.fth
+++ b/src/app/esp32-extra/tools/webcontrols.fth
@@ -1,4 +1,4 @@
-marker -webcontrols.fth  cr lastacf .name #19 to-column .( 31-05-2023 ) \ By J.v.d.Ven
+marker -webcontrols.fth  cr lastacf .name #19 to-column .( 11-11-2023 ) \ By J.v.d.Ven
 
 needs /circular    extra.fth
 

--- a/src/app/esp32-extra/tools/wsping.fth
+++ b/src/app/esp32-extra/tools/wsping.fth
@@ -1,12 +1,12 @@
-marker wsping.fth  cr lastacf .name #19 to-column .( 19-05-2023 ) \ By J.v.d.Ven
+marker -wsping.fth  cr lastacf .name #19 to-column .( 11-11-2023 ) \ By J.v.d.Ven
 
-\ For Web-server-light.f to update their ARP chache
+\ For Web-server-light.f to update ARP caches of the gforth webservers
 
 
 Also hidden decimal
 needs lwip-send rcvfile.fth
 
-create prefix$ ," 192.168.0."
+0 value prefix$
 #201 value master
 2variable range-gforth-servers
 
@@ -30,9 +30,7 @@ create prefix$ ," 192.168.0."
      then ;
 
 : ForUdpRange  ( from n cfa - )
-\  dup cr .name
-cr
-   -rot bounds
+   cr -rot bounds
       ?do  i prefix$ count pad lplace dec(.) pad +lplace
            pad lcount cr 2dup type
            2 pick execute

--- a/src/app/ntc-web/MachineSettings.fth
+++ b/src/app/ntc-web/MachineSettings.fth
@@ -1,11 +1,13 @@
-marker -MachineSettings.fth  cr lastacf .name #19 to-column .( 07-01-2023 ) \ By J.v.d.Ven
+marker -MachineSettings.fth  cr lastacf .name #19 to-column .( 11-11-2023 ) \ By J.v.d.Ven
 
+
+s" 192.168.0."    dup 1+ allocate drop dup to prefix$ place \ For the Gforth-servers
+
+\ Other involved servers. Edit/dissable the following 5 lines:
 s" 192.168.0.201" dup 1+ allocate drop dup to time-server$ place
-
-[ifdef] Rpi1-server$
-s" 192.168.0.201" dup 1+ allocate drop dup to Rpi1-server$ place \ For a sensorweb
-s" 192.168.0.212" dup 1+ allocate drop dup to ESP2-server$ place \ For a message board
-[then]
+s" 192.168.0.201" dup 1+ allocate drop dup to sensor-web$ place
+s" 192.168.0.212" dup 1+ allocate drop dup to msg-board$ place
+#200 #9 range-Gforth-servers 2!
 
 also html
 

--- a/src/app/ntc-web/readme.txt
+++ b/src/app/ntc-web/readme.txt
@@ -1,6 +1,20 @@
-Copy favicon.ico and ntc_web.fth to the file system of the ESP32.
+To see the temperature measured by a NTC in a web browser
+For: ~/cforth/src/app/esp32-extra
+Needed hardware: A NTC and an esp32
+
+$ Copy ~/cforth/src/app/ntc-web/app.fth   to   ~/cforth/src/app/esp32-extra
+$ cd ~/cforth/build/esp32-extra  
+$ rm *.*
+$ make flash
+
+Upload from ../src/app/ntc-web/
+favicon.ico AND ntc_web.fth   to the file system of the ESP32.
+
+Only when you use https://github.com/Jos-Ven/A-smart-home-in-Forth :
+  Edit and upload MachineSettings.fth to the file system of the ESP32 IF you are able to 
+  handle TcpTime packets. See: ~/cforth/src/app/esp32-extra/tools/timediff.fth
+  Disable servers you do not have.
 
 Reboot the ESP32 and compile ntc_web.fth
 To auto-run the application hit escape and enter:
 s" fl ntc_web.fth" s" start" file-it
-Or use the Load button in the Upload server.

--- a/src/app/sps30/MachineSettings.fth
+++ b/src/app/sps30/MachineSettings.fth
@@ -1,11 +1,13 @@
-marker -MachineSettings.fth  cr lastacf .name #19 to-column .( 07-01-2023 ) \ By J.v.d.Ven
+marker -MachineSettings.fth  cr lastacf .name #19 to-column .( 11-11-2023 ) \ By J.v.d.Ven
 
+
+s" 192.168.0."    dup 1+ allocate drop dup to prefix$ place \ For the Gforth-servers
+
+\ Other involved servers. Edit/dissable the following 5 lines:
 s" 192.168.0.201" dup 1+ allocate drop dup to time-server$ place
-
-[ifdef] Rpi1-server$
-s" 192.168.0.201" dup 1+ allocate drop dup to Rpi1-server$ place \ For a sensorweb
-s" 192.168.0.212" dup 1+ allocate drop dup to ESP2-server$ place \ For a message board
-[then]
+s" 192.168.0.201" dup 1+ allocate drop dup to sensor-web$ place
+s" 192.168.0.212" dup 1+ allocate drop dup to msg-board$ place
+#200 #9 range-Gforth-servers 2!
 
 also html
 

--- a/src/app/sps30/app.fth
+++ b/src/app/sps30/app.fth
@@ -39,12 +39,25 @@ alias m-init noop
      then  #3 /
 ;
 
-: ms ( ms - )
-   get-msecs +
-     begin   dup get-msecs - #10000 >
-     while   #10000000 us
+ f# 0 fvalue us-start   \ Must be updated after set-system-time
+
+: system-time>f ( us seconds -- ) ( f: -- us )
+   s" s>d d>f f# 1000000 f*  s>d d>f  f+ "  evaluate ; immediate
+
+: usf@         ( f: -- us )
+   s" dup dup sp@ get-system-time! system-time>f" evaluate ; immediate
+
+: ms@         ( -- ms )
+   f# .001 usf@ us-start f- f* f>d drop ;
+
+alias get-msecs ms@
+
+: ms ( ms -- )
+   s>d d>f f# 1000 f* usf@  f+
+     begin   fdup  usf@  f- f# 100000000 f>
+     while   #100000000 us
      repeat
-   get-msecs - #1000 * 0 max us
+   usf@  f- f>d drop abs us
 ;
 
 fl wifi.fth
@@ -58,17 +71,17 @@ previous
 
 fl files.fth
 fl server.fth
-fl tasking_rtos.fth        \ Pre-empty multitasking
+fl tasking_rtos.fth        \  Preemptive multitasking
 
 fl tools/extra.fth
 fl tools/table_sort.f
-fl tools/timediff.fth      \ Time calculations. The local time was received from a RPI
+fl tools/timediff.fth      \ Time calculations.
 fl tools/webcontrols.fth   \ Extra tags in ROM
 fl tools/svg_plotter.f
 fl tools/rcvfile.fth
 fl tools/wsping.fth
 fl tools/schedule-tool.f   \ Daily schedule
-fl ../sps30/sps30.fth      \ For sps30_webV2.fth
+fl ../sps30/sps30.fth      \ For sps30_web.fth
 
 
 : interrupt?  ( -- flag )
@@ -80,6 +93,7 @@ fl ../sps30/sps30.fth      \ For sps30_webV2.fth
 : load-startup-file  ( -- ior )   " start" ['] included catch   ;
 
 : app ( - ) \ Sometimes SPIFFS or a wifi connection causes an error. A reboot solves that.
+   usf@ to us-start
    banner  hex  interrupt? 0=
       if     s" start" file-exist?
            if   load-startup-file

--- a/src/app/sps30/readme.txt
+++ b/src/app/sps30/readme.txt
@@ -1,7 +1,34 @@
-To see the air quality in a web browser.
-Copy ../src/app/ntc-web/favicon.ico and sps30_web.fth to the file system of the ESP32.
+To see the air quality in a web browser
+For: ~/cforth/src/app/esp32-extra
+Needed hardware: A SPS30 and an esp32
+
+Backup your: ~/cforth/src/app/esp32-extra/app.fth
+$ Copy ~/cforth/src/app/sps30/app.fth   to   ~/cforth/src/app/esp32-extra
+$ cd ~/cforth/build/esp32-extra  
+$ rm *.*
+$ make flash
+
+Upload ../src/app/ntc-web/favicon.ico AND sps30_web.fth to the file system of the ESP32.
+
+Only when you use https://github.com/Jos-Ven/A-smart-home-in-Forth :
+  Edit and upload MachineSettings.fth to the file system of the ESP32 IF you are able to 
+  handle TcpTime packets. See: ~/cforth/src/app/esp32-extra/tools/timediff.fth
+  Disable servers you do not have.
 
 Reboot the ESP32 and compile sps30_web.fth
-To auto-run the application hit escape and enter:
+To auto-run the application hit escape and enter on the Esp32:
 s" fl sps30_web.fth" s" start" file-it
-Or use the Load button in the Upload server.
+
+
+The deep sleep of the ESP32 wakes up too early. The schedule handle this as follows:
+When the ESP32 wakes up and there is an entry at 00:00 containing sleep then:
+If there is no entry of in the running minute it puts the ESP32 into a deep sleep
+till the next entry.
+Then when it wakes up again it executes the entry of the running minute.
+At 00:00 the ESP32 will not go into a deep sleep.
+
+When there is no WiFi connection then the programm puts the esp32 into 
+a deep sleep for 30 minutes.
+Unless you disable the lines with SleepIfNotConnected in sps30_web.fth
+
+


### PR DESCRIPTION
Thanks to set-system-time and get-system-time! the time will now survive a deep sleep. Also added a simple HTML-form to input and set the system time. esp-wifi-disconnect is needed when you would like to switch form a WiFi connection to esp-now. Otherwise esp-now will not work well. Adapted 2 apps to take advantage of the new features.